### PR TITLE
Fix startup and testing sequence

### DIFF
--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             port: https
           initialDelaySeconds: 1
           periodSeconds: 5
-          timeoutSeconds: 2
+          timeoutSeconds: 3
           # 1 seconds * 180 = 3 minutes
           failureThreshold: 180
         readinessProbe:
@@ -75,7 +75,7 @@ spec:
             port: https
           initialDelaySeconds: 1
           periodSeconds: 5
-          timeoutSeconds: 2
+          timeoutSeconds: 3
           # 1 seconds * 180 = 3 minutes
           failureThreshold: 180
         volumeMounts:
@@ -111,8 +111,8 @@ spec:
             path: /
             port: http
           initialDelaySeconds: 1
-          periodSeconds: 5
-          timeoutSeconds: 2
+          periodSeconds: 30
+          timeoutSeconds: 30
           # 1 seconds * 180 = 3 minutes
           failureThreshold: 180
         env:

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@
 
 HELM_TEST_ARGS="${@:---cleanup}"  # cleanup test pod by default
 
-RELEASE_NAME="test-$(date -u +%Y%m%d-%H%M%S)"
+RELEASE_NAME="helm-chart-test-$(date -u +%Y%m%d-%H%M%S)"
 
 function finish() {
   echo "> Deleting release $RELEASE_NAME"
@@ -15,7 +15,10 @@ trap finish EXIT
 
 echo "> Installing helm chart, waiting until app is ready..."
 dataKey="$(docker run --rm cyberark/conjur data-key generate)"
-helm install --wait --name $RELEASE_NAME --set "dataKey=$dataKey" ./conjur-oss
+helm install --wait \
+             --timeout 900 \
+             --name $RELEASE_NAME \
+             --set "dataKey=$dataKey" ./conjur-oss
 
 echo "> Running helm tests with arguments: $HELM_TEST_ARGS"
 helm test $HELM_TEST_ARGS $RELEASE_NAME


### PR DESCRIPTION
Some of the startup tests and checks did not take into account that
asset precompilation might not ever finish with short timeouts. This
change should ensure that our startup will have at least one
long-running request. We also added additional details to test container
names for easier visibility.