### PR TITLE
Fixed test runner

### DIFF
--- a/conjur-oss/templates/tests/test-simple-install-configmap.yaml
+++ b/conjur-oss/templates/tests/test-simple-install-configmap.yaml
@@ -5,5 +5,5 @@ metadata:
 data:
   run.sh: |-
     @test "Testing that Conjur status page is up" {
-      curl "http://{{ .Release.Name }}-conjur-oss/" | grep 'Conjur Status'
+      curl -f --cacert /cacert/tls.crt "https://{{ .Release.Name }}-conjur-oss/" | grep 'Conjur Status'
     }

--- a/conjur-oss/templates/tests/test-simple-install.yaml
+++ b/conjur-oss/templates/tests/test-simple-install.yaml
@@ -6,31 +6,43 @@ metadata:
     "helm.sh/hook": test-success
 spec:
   initContainers:
-  - name: test-framework
-    image: dduportal/bats:0.4.0
+  - name: {{ .Release.Name }}-bats-init
+    image: bats/bats:v1.1
     command:
     - "bash"
     - "-exc"
     - |
       # copy bats to tools dir
-      cp -R /usr/local/libexec/ /tools/bats/
+      cp -R /opt/bats/libexec/bats-core/ /tools/bats/
     volumeMounts:
     - mountPath: /tools
       name: tools
   containers:
   - name: {{ .Release.Name }}-test
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    workingDir: "/tools/bats"
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+    env:
+    - name: PATH
+      value: "/tools/bats:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     volumeMounts:
     - mountPath: /tests
       name: tests
       readOnly: true
     - mountPath: /tools
       name: tools
+    - mountPath: /cacert
+      name: {{ .Release.Name }}-test-conjur-ssl-ca-cert-volume
+      readOnly: true
   volumes:
   - name: tests
     configMap:
       name: {{ template "conjur-oss.fullname" . }}-tests
+  - name: {{ .Release.Name }}-test-conjur-ssl-ca-cert-volume
+    secret:
+      secretName: {{ .Release.Name }}-conjur-ssl-ca-cert
+      # Permission == 0400. JSON spec doesn’t support octal notation.
+      defaultMode: 256
   - name: tools
     emptyDir: {}
   restartPolicy: Never

--- a/e2e/delete-conjur.sh
+++ b/e2e/delete-conjur.sh
@@ -16,7 +16,7 @@ fi
 
 for conjur_release in ${conjur_releases}; do
   echo "Deleting Conjur release '${conjur_release}'..."
-  helm delete "${conjur_release}"
+  helm delete --purge "${conjur_release}"
 done
 
 echo "Done!"


### PR DESCRIPTION
We now make sure to poke the correct endpoint and use TLS validation. In
the process, BATS reference was upgraded to v1.1 (from 0.4.0).