### PR TITLE
Fixed test to use the exact service name

### DIFF
--- a/conjur-oss/templates/tests/test-simple-install-configmap.yaml
+++ b/conjur-oss/templates/tests/test-simple-install-configmap.yaml
@@ -5,5 +5,5 @@ metadata:
 data:
   run.sh: |-
     @test "Testing that Conjur status page is up" {
-      curl -f --cacert /cacert/tls.crt "https://{{ .Release.Name }}-conjur-oss/" | grep 'Conjur Status'
+      curl -f --cacert /cacert/tls.crt https://{{ template "conjur-oss.fullname" . }}/ | grep 'Conjur Status'
     }


### PR DESCRIPTION
Old code was brittle if the helm chart name was overridden.