### PR TITLE
Revert "Update to version 1.3.4.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.3.4.1](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.4.1) - 2019-01-18
-### Fixed
-- Fixed the test service name to use the exact name template
-
 ## [1.3.4](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.4) - 2019-01-08
 ### Added
 - New [`authenticators` parameter](./conjur-oss#configuration), optionally applied to Conjur through

--- a/conjur-oss/Chart.yaml
+++ b/conjur-oss/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: conjur-oss
 home: https://www.conjur.org
-version: 1.3.4.1
+version: 1.3.4
 description: A Helm chart for CyberArk Conjur
 icon: https://xebialabs-clients-iglusjax.stackpathdns.com/assets/files/logos/CyberArkConjurLogoWhiteBlue.png
 keywords:


### PR DESCRIPTION
This reverts commit d070a2122d20ae974772a7de6e8e121f99320cef.

Apparently semVer is evaluated in a very specific (and unintuitive way
for helm charts)

- https://github.com/helm/helm/issues/2797
- https://github.com/helm/helm/issues/2797#issuecomment-334957930