### PR TITLE
Made the Postgres persistent volume be switchable on/off

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -111,10 +111,12 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`nginx.image.repository`|NGINX Docker image repository|`"nginx"`|
 |`nginx.image.tag`|NGINX Docker image tag|`"1.15"`|
 |`nginx.image.pullPolicy`|Pull policy for NGINX Docker image|`"IfNotPresent"`|
-|`persistentVolumeSize`|Size of persistent volume to be created for PostgreSQL|`"8Gi"`|
 |`postgres.image.pullPolicy`|Pull policy for postgres Docker image|`"IfNotPresent"`|
 |`postgres.image.repository`|postgres Docker image repository|`"postgres"`|
 |`postgres.image.tag`|postgres Docker image tag|`"10.1"`|
+|`postgres.persistentVolume.create`|Create a peristent volume to back the PostgreSQL data|`true`|
+|`postgres.persistentVolume.size`|Size of persistent volume to be created for PostgreSQL|`"8Gi"`|
+|`postgres.persistentVolume.storageClass`|Storage class to be used for PostgreSQL persistent volume claim|`nil`|
 |`rbac.create`|Controls whether or not RBAC resources are created|`true`|
 |`replicaCount`|Number of desired Conjur pods|`1`|
 |`service.external.annotations`|Annotations for the external LoadBalancer|`[service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp]`|
@@ -128,7 +130,6 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`ssl.altNames`|Subject Alt Names for generated Conjur certificate and ingress|`[]`|
 |`ssl.expiration`|Expiration limit for generated certificates|`365`|
 |`ssl.hostname`|Hostname and Common Name for generated certificate and ingress|`"conjur.myorg.com"`|
-|`storageClass`|Storage class to be used for PostgreSQL persistent volume claim|`nil`|
 |`postgresLabels`|Extra Kubernetes labels to apply to Conjur PostgreSQL resources|`{}`|
 
 ## Contributing

--- a/conjur-oss/templates/persistent-volume-claim.yaml
+++ b/conjur-oss/templates/persistent-volume-claim.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.persistentVolumeSize }}
+{{ if .Values.postgres.persistentVolume.create }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -18,8 +18,8 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.persistentVolumeSize }}
-  {{ if .Values.storageClass }}
-  storageClassName: {{ .Values.storageClass }}
+      storage: {{ .Values.postgres.persistentVolume.size }}
+  {{ if .Values.postgres.persistentVolume.storageClass }}
+  storageClassName: {{ .Values.postgres.persistentVolume.storageClass }}
   {{ end }}
 {{ end }}

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -38,6 +38,7 @@ spec:
   - image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
     imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
     name: postgres
+{{ if .Values.postgres.persistentVolume.create }}
     volumeMounts:
     - mountPath: "/var/lib/postgresql"
       name: postgres-data
@@ -45,5 +46,6 @@ spec:
   - name: postgres-data
     persistentVolumeClaim:
       claimName: {{ .Release.Name }}-conjur-oss-pvc
+{{- end }}
 ---
 {{ end }}

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -34,13 +34,15 @@ nginx:
     repository: nginx          # https://hub.docker.com/_/nginx/
     tag: '1.15'
 
-persistentVolumeSize: 8Gi
-
 postgres:
   image:
     pullPolicy: IfNotPresent
     repository: postgres       # https://hub.docker.com/_/postgres/
     tag: '10.1'
+  persistentVolume:
+    create: true
+    size: 8Gi
+    storageClass:
 
 # Additional labels to apply to all conjur resources
 postgresLabels: {}
@@ -62,8 +64,6 @@ replicaCount: 1
 #  cpu: 100m
 #  memory: 128Mi
 resources: {}
-
-storageClass:
 
 service:
   external:

--- a/e2e/install-conjur-no-pv.sh
+++ b/e2e/install-conjur-no-pv.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+helm install \
+  --set dataKey="$(docker run --rm cyberark/conjur data-key generate)" \
+  --set postgres.persistentVolume.create="false" \
+  ../conjur-oss


### PR DESCRIPTION
Old code did not actually work properly when changing the PV size to 0
and the config values were in various places so we are now ensuring that
they are all tied together.