### PR TITLE
Upgraded server ciphers to only allow TLSv1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7) - 2019-01-31
+### Changed
+- Server ciphers have been upgraded to TLS1.2 levels.
+
 ## [1.3.6](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.6) - 2019-01-22
 ### Changed
 - Changed the default Postgres resource from Pod to Deployment to fix GKE marketplace app

--- a/conjur-oss/Chart.yaml
+++ b/conjur-oss/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: conjur-oss
 home: https://www.conjur.org
-version: 1.3.6
+version: 1.3.7
 description: A Helm chart for CyberArk Conjur
 icon: https://xebialabs-clients-iglusjax.stackpathdns.com/assets/files/logos/CyberArkConjurLogoWhiteBlue.png
 keywords:

--- a/conjur-oss/files/conjur.conf
+++ b/conjur-oss/files/conjur.conf
@@ -6,11 +6,6 @@ server {
 
   ssl_verify_client optional_no_ca;
 
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-
-  ssl_dhparam /etc/nginx/dhparams.pem;
-  ssl_session_cache shared:SSL:10m;
-
   listen 9443 ssl;
   listen [::]:9443 ssl;
 

--- a/conjur-oss/files/nginx.conf
+++ b/conjur-oss/files/nginx.conf
@@ -15,6 +15,19 @@ http {
     client_max_body_size 10M;
     proxy_read_timeout 600s;
 
+    # Prevent DoS attacks
+    reset_timedout_connection on;
+
+    # Speed up SSL connections
+    ssl_session_timeout 10m;
+    ssl_session_cache   shared:SSL:10m;
+
+    # Custom security-minded SSL settings
+    ssl_dhparam /etc/nginx/dhparams.pem;
+    ssl_protocols TLSv1.3 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers 'ALL:!RSA:!SHA:!aNULL:!eNULL:!EXPORT:!MEDIUM:!LOW:!CAMELLIA:!3DES:!DES:!MD5:!PSK:!RC4:!DSS:!SRP:!DSS:!SEED:!SSLv3:!SSLv2:!IDEA:!aGOST';
+
     log_format syslog '$http_host '
                       '$remote_addr '
                       '"$request" $status $body_bytes_sent '


### PR DESCRIPTION
Per https://github.com/conjurinc/appliance/issues/593, we are now using
a much more secure cipherlist for our HTTPS termination.