### PR TITLE
fix helm chart for K8s 1.16+

### DIFF
--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "conjur-oss.fullname" . }}

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -19,7 +19,7 @@ spec:
   - port: 5432
   selector: *AppPostgresServiceLabels
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-postgres


### PR DESCRIPTION
Fixes per https://kubernetes.io/blog/2019/09/18/kubernetes-1-16-release-announcement/

Prevents this error in new K8s versions and minikube:
```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Deployment" in version "apps/v1beta1"
```