### PR TITLE
Fixed issues in README instructions for custom installation

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -70,7 +70,7 @@ ssl:
 ```
 
 ```sh-session
-$ helm install -f custom-values.yaml \
+$ helm install conjur-oss -f custom-values.yaml \
   https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v<VERSION>/conjur-oss-<VERSION>.tgz
 ```
 
@@ -79,10 +79,10 @@ $ helm install -f custom-values.yaml \
 created. For example, given the following command:
 
 ```sh-session
-$ kubectl exec $POD_NAME --container=conjur-oss conjurctl account create example
+$ kubectl exec $POD_NAME --container=conjur-oss conjurctl account create default
 ```
 
-The chart value for `account` would be expected to equal `example`.
+The chart value for `account` would be expected to equal `default`.
 
 ## Uninstalling the Chart
 


### PR DESCRIPTION
Made two small fixes in the README:

1. Added `conjur-oss` to the customer installation command, because it fails without it.
1. Changed the example account name from `example` to `deafult`. The native flow of a user would be to copy and paste the example. Since the default account name generated by the Helm chart is called `default`, I aligned the example accordingly.