### PR TITLE
Add Kubernetes-in-Docker based automated tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,55 @@ on:
   push:
 
 jobs:
-  tests:
-    name: Run Tests
+  linter:
+    name: Run Helm Linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.2.1
+
+      - name: Run linter
+        run: helm lint --set dataKey=BLOB ./conjur-oss
+
+  install-test-helm-v3:
+    name: Install/test Conjur with Helm V3 on KinD Cluster
+    needs: [ linter ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kube-tag:
+          - v1.18.2
+          - v1.16.9
+          - v1.14.10
+          - v1.12.10
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.2.1
+
+      - name: Create k8s KinD Cluster
+        uses: helm/kind-action@v1.0.0-rc.1
+        with:
+          node_image: "kindest/node:${{ matrix.kube-tag }}"
+          cluster_name: kube_${{ matrix.kube-tag }}
+
+      - name: Run integration tests
+        run: ./test-minimal.sh
+
+  install-test-helm-v2:
+    name: Install/test Conjur with Helm V2 on KinD Cluster
+    needs:
+      - linter
+      - install-test-helm-v3
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -18,7 +65,10 @@ jobs:
           version: v2.16.6
 
       - name: Create k8s KinD Cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
+        uses: helm/kind-action@v1.0.0-rc.1
+        with:
+          node_image: "kindest/node:v1.18.2"
+          cluster_name: kube_v1.18.2_helm2
 
       - name: Initialise Helm
         run: |
@@ -46,9 +96,6 @@ jobs:
 
           # Initialise
           helm init --service-account tiller --wait
-
-      - name: Run linter
-        run: helm lint --set dataKey=BLOB ./conjur-oss
 
       - name: Run integration tests
         run: ./test-minimal.sh

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -41,6 +41,8 @@ spec:
     metadata:
       labels: *AppPostgresLabels
     spec:
+      securityContext:
+        fsGroup: 999
       containers:
       - image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
         imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}

--- a/conjur-oss/templates/tests/test-simple-install.yaml
+++ b/conjur-oss/templates/tests/test-simple-install.yaml
@@ -2,8 +2,18 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-test-{{ randAlphaNum 5 | lower }}"
+  labels:
+    app: {{ template "conjur-oss.name" . }}
+    chart: {{ template "conjur-oss.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   annotations:
     "helm.sh/hook": test-success
+{{ if .Values.test.deleteOnSuccess }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{ else }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{ end }}
 spec:
   initContainers:
   - name: {{ .Release.Name }}-bats-init

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -77,13 +77,19 @@ service:
     port: 443
     type: NodePort
 
+serviceAccount:
+  create: true
+  name:
+
 ssl:
   expiration: 365 # days
   hostname: "conjur.myorg.com"
   altNames: []
 
-serviceAccount:
-  create: true
-  name:
+test:
+  deleteOnSuccess: true  # If true, test pods are deleted upon successful
+                         # test completion. Otherwise, test pods are not
+                         # automatically deleted upon test completion,
+                         # regardless of test success or failure.
 
 tolerations: []

--- a/e2e/delete-conjur.sh
+++ b/e2e/delete-conjur.sh
@@ -2,6 +2,8 @@
 
 set -o pipefail
 
+source ../is_helm_v2.sh
+
 if [ "$(which jq)" == "" ]; then
   echo "ERROR: Could not find jq utility!"
   exit 1
@@ -16,7 +18,11 @@ fi
 
 for conjur_release in ${conjur_releases}; do
   echo "Deleting Conjur release '${conjur_release}'..."
-  helm delete --purge "${conjur_release}"
+  if is_helm_v2; then
+    helm delete --purge "${conjur_release}"
+  else
+    helm delete "${conjur_release}"
+  fi
 done
 
 echo "Done!"

--- a/is_helm_v2.sh
+++ b/is_helm_v2.sh
@@ -1,0 +1,7 @@
+function is_helm_v2()
+{
+  # Helm Version 2 supports a `--server` command line option for the
+  # `helm version` command, whereas newer versions of Helm will return
+  # an error if `--server` is used.
+  helm version --server > /dev/null 2>&1
+}

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,18 @@
 #!/bin/bash -e
 
+source ./is_helm_v2.sh
+
 HELM_ARGS="$@"
 
 if [ -z "$HELM_ARGS" ]; then
   data_key="$(docker run --rm cyberark/conjur data-key generate)"
   HELM_ARGS="--set dataKey=$data_key"
+fi
+
+if is_helm_v2; then
+    HELM_ARGS="$HELM_ARGS --name conjur-oss"
+else
+    HELM_ARGS="$HELM_ARGS conjur-oss"
 fi
 
 helm install $HELM_ARGS ./conjur-oss

--- a/test-minimal.sh
+++ b/test-minimal.sh
@@ -1,34 +1,23 @@
 #!/bin/bash -e
 
-# This script runs the minimal helm test, without relies on external load balancers
-# or persistent volumes. This is suitable for environment where these resources aren't
-# available.
+source ./is_helm_v2.sh
 
-# Run helm test
-# Any arguments passed to this script will be passed to `helm test`.
+# This script runs the minimal helm test, without relies on external load
+# balancers or persistent volumes. This is suitable for environment where
+# these resources aren't available.
+#
+# This test also enables Helm test logging by default.
 
-HELM_TEST_ARGS="${@:---cleanup}"  # cleanup test pod by default
+export HELM_INSTALL_ARGS="--set service.external.enabled=false \
+                   --set postgres.persistentVolume.create=false"
 
-RELEASE_NAME="helm-chart-test-$(date -u +%Y%m%d-%H%M%S)"
+export HELM_INSTALL_TIMEOUT="180"
+if ! is_helm_v2; then
+  # Helm v3 requires units for timeout values
+  HELM_INSTALL_TIMEOUT+="s"
+fi
 
-function finish() {
-  echo "> Deleting release $RELEASE_NAME"
-  helm del --purge $RELEASE_NAME
-}
-trap finish EXIT
+export HELM_TEST_LOGGING=${HELM_TEST_LOGGING:-true}
 
-echo "> Installing helm chart, waiting until app is ready..."
-dataKey="$(docker run --rm cyberark/conjur data-key generate)"
+./test.sh
 
-# External load balancers and persistent volumes are not always available
-# so they are turned off.
-helm install --wait \
-             --timeout 180 \
-             --name $RELEASE_NAME \
-             --set "dataKey=$dataKey" \
-             --set "service.external.enabled=false" \
-             --set "postgres.persistentVolume.create=false" \
-             ./conjur-oss
-
-echo "> Running helm tests with arguments: $HELM_TEST_ARGS"
-helm test --logs $HELM_TEST_ARGS $RELEASE_NAME


### PR DESCRIPTION
This change adds automated testing that uses Kubernetes-in-Docker (KinD)
to spin up Kubernetes clusters using various Kubernetes versions.

Currently, the Kubernetes versions being used for testing are:
- Kubernetes v1.18.2
- Kubernetes v1.16.9
- Kubernetes v1.14.10
- Kubernetes v1.12.10

The tests that are run for each version of Kubernetes include:
- KinD create of a Kubernetes cluster.
- Helm install of Conjur/Nginx + backend Postgres database.
- Helm test of the Conjur deployment that confirms that the
  Conjur status page is active.
- Helm delete of Conjur release.
- KinD delete of the Kubernetes cluster.

This change also includes some Helm v2 -> Helm v3 syntax changes, since Helm v3
is our officially supported version. Also, github action test is modified to use Helm v3.2.

Also included is the addition of a new chart values setting to indicate whether the
test pods should be automatically deleted when the helm test passes. From values.yaml:
```
test:
  deleteOnSuccess: true  # If true, test pods are deleted upon successful
                         # test completion. Otherwise, test pods are not
                         # automatically deleted upon test completion,
                         # regardless of test success or failure.
```
This defaults to `true`, but should be set to `false` e.g. when `helm test` logging is enabled,
since `helm test` needs to display the test pod log before the pod gets deleted, even for
test success.

Fixes Issue #52 