### PR TITLE
Adds GCP-based Jenkins test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./test-minimal.sh
 
   install-test-helm-v2:
-    name: Install/test Conjur with Helm V2 on KinD Cluster
+    name: Install/test Conjur with Helm V2 on KinD Cluster (v1.18.2)
     needs:
       - linter
       - install-test-helm-v3

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,37 @@
+#!/usr/bin/env groovy
+
+import groovy.transform.Field
+
+@Field
+def TAG = ""
+
+pipeline {
+  agent { label 'executor-v2' }
+
+  options {
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+
+  triggers {
+    cron(getDailyCronString())
+  }
+
+  stages {
+
+    stage('GKE Build and Test') {
+      environment {
+        HELM_VERSION = "3.1.3"
+      }
+      steps {
+        sh 'cd ci && summon ./jenkins_build.sh'
+      }
+    }
+  }
+
+  post {
+    always {
+      cleanupAndNotify(currentBuild.currentResult)
+    }
+  }
+}

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,36 @@
+FROM google/cloud-sdk
+
+ARG HELM_VERSION=3.1.3
+ARG KUBECTL_VERSION=1.16.9
+
+RUN mkdir -p /src
+WORKDIR /src
+
+# Install Docker client
+RUN apt-get update && \
+    apt-get install -y apt-transport-https \
+                       ca-certificates \
+                       curl \
+                       gnupg2 \
+                       software-properties-common \
+                       wget && \
+    distro="$(. /etc/os-release; echo $ID)" && \
+    release="$(lsb_release -cs)" && \
+    curl -fsSL "https://download.docker.com/linux/$distro/gpg" > /tmp/docker_repo_key && \
+    apt-key add /tmp/docker_repo_key && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$distro $release stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Helm client
+RUN wget https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+    tar xvf helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+    mv linux-amd64/helm /usr/local/bin/ && \
+    rm helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+    rm -rf linux-amd64
+
+# Install Kubernetes client
+RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl

--- a/ci/jenkins_build.sh
+++ b/ci/jenkins_build.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -euo pipefail
+
+source ../utils.sh
+
+# This script does the following in sequence:
+# - Runs a Helm install of a Conjur OSS server
+# - Runs a Helm test that deploys a test container that runs a
+#   Bash Automated Test System (a.k.a. "Bats") test script that
+#   confirms that the Conjur server's status page is active.
+#
+# Optional Environment Variables:
+#   CONJUR_NAMESPACE:     Namespace to use for Conjur deployment. The
+#                         namespace is created if it doesn't exist.
+#   HELM_INSTALL_TIMEOUT: Helm install timeout in seconds.
+#                         Defaults to `180`.
+#   HELM_TEST_LOGGING:    Set to true to enable Helm test log collection.
+#                         Defaults to false.
+#   HELM_VERSION:         Helm client version to use for the test.
+#                         Defaults to '3.1.3'.
+#   KUBECTL_VERSION:      Kubectl client version to use for the test.
+#                         Defaults to '1.16.9'.
+#   SKIP_GCLOUD_LOGIN:    If set to 'true', then skip Gcloud authentication.
+#                         This is useful for local testing whereby you've
+#                         already authenticated with GCP and/or have 'kubectl'
+#                         access to a cluster. Defaults to 'false'.
+
+test_id="$(random_string)"
+
+export CONJUR_NAMESPACE="${CONJUR_NAMESPACE:-conjur-oss-test-$test_id}"
+export HELM_INSTALL_TIMEOUT="${HELM_INSTALL_TIMEOUT:-180}"
+export HELM_TEST_LOGGING="${HELM_TEST_LOGGING:-true}"
+export HELM_VERSION="${HELM_VERSION:-3.1.3}"
+export KUBECTL_VERSION="${KUBECTL_VERSION:-1.16.9}"
+export RELEASE_NAME="$CONJUR_NAMESPACE"
+export SKIP_GCLOUD_LOGIN="${SKIP_GCLOUD_LOGIN:-false}"
+
+announce "Building gcloud/kubectl/helm client image..."
+# Build the gcloud/kubectl/helm client container image
+tools_image_name="conjur-oss-helm-kubectl"
+docker build -t "${tools_image_name}" \
+             --quiet \
+             --build-arg HELM_VERSION="$HELM_VERSION" \
+             --build-arg KUBECTL_VERSION="$KUBECTL_VERSION" \
+             -f Dockerfile \
+             .
+
+tmp_dir="$(pwd)/.tmp"
+tmp_bin_dir="${tmp_dir}/bin"
+mkdir -p "${tmp_bin_dir}" \
+         "${tmp_dir}/.kube" \
+         "${tmp_dir}/.config"
+export PATH="${tmp_bin_dir}:${PATH}"
+
+# Create a local alias for running 'gcloud' in client container
+cat > "${tmp_bin_dir}/gcloud" <<EOF
+  docker run --rm \
+    --ipc="host" \
+    -v "${tmp_dir}/.kube:/root/.kube" \
+    -v "${tmp_dir}/.config:/root/.config" \
+    --entrypoint /usr/bin/gcloud \
+    "${tools_image_name}" \
+    "\$@"
+EOF
+chmod +x "${tmp_bin_dir}/gcloud"
+
+# Create a local alias for running 'helm' in client container
+cat > "${tmp_bin_dir}/helm" <<EOF
+  docker run --rm \
+    -v "${tmp_dir}/.kube:/root/.kube" \
+    -v "${tmp_dir}/.config:/root/.config" \
+    -v "$(cd ../conjur-oss; pwd):/src/conjur-oss:ro" \
+    --entrypoint /usr/local/bin/helm \
+    "${tools_image_name}" \
+    "\$@"
+EOF
+chmod +x "${tmp_bin_dir}/helm"
+
+# Create a local alias for running 'kubectl' in client container
+cat > "${tmp_bin_dir}/kubectl" <<EOF
+  docker run --rm \
+    -v "${tmp_dir}/.kube:/root/.kube" \
+    -v "${tmp_dir}/.config:/root/.config" \
+    --entrypoint /usr/local/bin/kubectl \
+    "${tools_image_name}" \
+    "\$@"
+EOF
+chmod +x "${tmp_bin_dir}/kubectl"
+
+if [ "$SKIP_GCLOUD_LOGIN" = true ]; then
+  cp "$HOME/.kube/config" "$tmp_dir/.kube/config"
+  cp -r "$HOME/.config/gcloud" "$tmp_dir/.config/gcloud"
+else
+  announce "Logging in to GCP..."
+  # It is assumed that the environment variables below are set by summon.
+  docker run --rm \
+             -e GCLOUD_CLUSTER_NAME \
+             -e GCLOUD_PROJECT_NAME \
+             -e GCLOUD_SERVICE_KEY="/tmp${GCLOUD_SERVICE_KEY}" \
+             -e GCLOUD_ZONE \
+             -e DOCKER_REGISTRY_URL \
+             -e DOCKER_REGISTRY_PATH \
+             -v "${tmp_dir}/.kube:/root/.kube" \
+             -v "${tmp_dir}/.config:/root/.config" \
+             -v "${GCLOUD_SERVICE_KEY}:/tmp${GCLOUD_SERVICE_KEY}" \
+             -v "$(pwd):/src:ro" \
+             "${tools_image_name}" \
+             bash -c "./platform_login.sh"
+fi
+
+# Fix permissions on files created within Docker
+docker run --rm \
+           -v "${tmp_dir}/.kube:/root/.kube" \
+           -v "${tmp_dir}/.config:/root/.config" \
+           "${tools_image_name}" \
+           bash -c "chown ${UID} -R /root/.kube/config /root/.config/*"
+
+function delete_namespace {
+  announce "Deleting namespace $CONJUR_NAMESPACE"
+  kubectl delete namespace --ignore-not-found=true "$CONJUR_NAMESPACE"
+}
+
+if ! is_helm_v2; then
+  # Helm v3 requires units for timeout values
+  HELM_INSTALL_TIMEOUT+="s"
+else
+  helm init --upgrade
+fi
+
+announce "Deploying and testing Conjur OSS"
+cd ..
+trap delete_namespace EXIT
+if ! ./test.sh; then
+  announce "                 FAILED"
+  exit 1
+fi
+announce "                 SUCCESS"

--- a/ci/platform_login.sh
+++ b/ci/platform_login.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function log_in() {
+  gcloud auth activate-service-account \
+    --key-file "${GCLOUD_SERVICE_KEY}"
+  gcloud container clusters get-credentials \
+    "${GCLOUD_CLUSTER_NAME}" \
+    --zone "${GCLOUD_ZONE}" \
+    --project "${GCLOUD_PROJECT_NAME}"
+  docker login "${DOCKER_REGISTRY_URL}" \
+    -u oauth2accesstoken \
+    -p "$(gcloud auth print-access-token)"
+}
+
+echo "Logging into GKE and Docker registry..."
+
+attempt=0
+
+log_in
+until [[ "$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null)" != "" ]]; do
+  echo -n '.'
+  sleep 2
+
+  attempt=$(( attempt + 1 ))
+  if [ $attempt -gt 10 ]; then
+    echo
+    echo "ERROR: Could not log into Gcloud!"
+    exit 1
+  fi
+
+  log_in
+done
+
+echo "Logged into remote resources."

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -1,0 +1,7 @@
+GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
+GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
+GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
+GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
+
+DOCKER_REGISTRY_URL: us.gcr.io
+DOCKER_REGISTRY_PATH: us.gcr.io/conjur-gke-dev

--- a/is-helm-v2.sh
+++ b/is-helm-v2.sh
@@ -1,7 +1,0 @@
-function is_helm_v2()
-{
-  # Helm Version 2 supports a `--server` command line option for the
-  # `helm version` command, whereas newer versions of Helm will return
-  # an error if `--server` is used.
-  helm version --server > /dev/null 2>&1
-}

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-source ./is-helm-v2.sh
+source ./utils.sh
 
 HELM_RELEASE=${HELM_RELEASE:-conjur-oss}
 
@@ -24,7 +24,7 @@ if [ ! -z "$CONJUR_NAMESPACE" ]; then
   if ! kubectl get namespace "$CONJUR_NAMESPACE" 2>/dev/null; then
     kubectl create namespace "$CONJUR_NAMESPACE"
   fi
-  HELM_ARGS="$HELM_ARGS -n $CONJUR_NAMESPACE"
+  HELM_ARGS="$HELM_ARGS --namespace $CONJUR_NAMESPACE"
 fi
 
 helm install $HELM_ARGS ./conjur-oss

--- a/test-minimal.sh
+++ b/test-minimal.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-source ./is-helm-v2.sh
+source ./utils.sh
 
 # This script runs the minimal helm test, without relies on external load
 # balancers or persistent volumes. This is suitable for environment where

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,21 @@
+function is_helm_v2() {
+  version=$(helm version | grep "SemVer:\"v2")
+  if [ ! -z "$version" ]; then
+      true
+  else
+      false
+  fi
+}
+
+function random_string() {
+  cat /dev/urandom | \
+      tr -dc 'a-z0-9' | \
+      head -c 8 || \
+      true
+}
+
+function announce() {
+    echo "==================================================="
+    echo "$1"
+    echo "==================================================="
+}


### PR DESCRIPTION
### What does this PR do?
This change adds GCP/GKE based Jenkins tests that do the following
using Helm v3:
 - Creates a Kubernetes namespace
 - Runs a Helm install of a Conjur OSS server
 - Runs a Helm test that deploys a test container that
   confirms that the Conjur server's status page is active.
 - Does a Helm delete of the Conjur OSS release
 - Deletes the namespace

This change Also fixes an issue with running the 'test.sh' script with Helm v2
in that the 'helm test ...' and 'helm delete ...' commands were
incorrectly including a namespace argument (a namespace argument
is only used for 'helm install ...' for Helm v2).

This Jenkins test requires a change in the jenkins-seed repo:
    https://github.com/conjurinc/jenkins-seed/pull/72

### What ticket does this PR close?
Issue #65 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation