### PR TITLE
Helm ocp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [v2.0.3] - 2020-12-21
+
+### Added
+- The Conjur OSS helm chart has Community support for deploying Conjur OSS to OpenShift 4.x
+  [cyberark/conjur-oss-helm-chart#60](https://github.com/cyberark/conjur-oss-helm-chart/issues/60)
+
 ## [v2.0.2] - 2020-12-02
 
 ### Changed

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -17,6 +17,7 @@ Conjur Open Source is part of the CyberArk Privileged Access Security Solution w
 - [Prerequisites and Guidelines](#prerequisites-and-guidelines)
 - [Installing the Chart](#installing-the-chart)
   * [Simple Install](#simple-install)
+  * [Installation on OCP](#installation-on-ocp)
   * [Custom Installation](#custom-installation)
     + [Example: Installation Using Command Line Arguments](#example-installation-using-command-line-arguments)
     + [Example: Installation Using Custom YAML File](#example-installation-using-custom-yaml-file)
@@ -48,9 +49,9 @@ Conjur Open Source is part of the CyberArk Privileged Access Security Solution w
   * Kubernetes and Helm access to the cluster/namespace is limited to
     security administrators via Role-Based Access Control (RBAC).
 - Kubernetes 1.7+
+- OCP 4.x+ (**Preliminary [Community level](https://github.com/cyberark/community/blob/master/Conjur/conventions/certification-levels.md#community) support only**)
 - Helm v3+. The chart may work with older versions of
   Helm but that deployment isn't specifically supported.
-- Installation on OpenShift is not currently supported.
 - It is recommended that auto-upgrades of Kubernetes version not be
   used in the Kubernetes platform in which Conjur is deployed. Kubernetes
   version upgrades should be done in concert with Conjur version upgrades
@@ -107,6 +108,24 @@ $  helm install \
    "$HELM_RELEASE" \
    ./conjur-oss
 ```
+
+### Installation on OCP
+
+To install Conjur on OCP using the `openshift.enabled=true` value:
+
+```sh-session
+$  CONJUR_NAMESPACE=<conjur-namespace>
+$  oc create namespace "$CONJUR_NAMESPACE"
+$  DATA_KEY="$(docker run --rm cyberark/conjur data-key generate)"
+$  HELM_RELEASE=<helm-release>
+$  helm install \
+   -n "$CONJUR_NAMESPACE" \
+   --set openshift.enabled=true \
+   --set dataKey="$DATA_KEY" \
+   "$HELM_RELEASE" \
+   https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v<VERSION>/conjur-oss-<VERSION>.tgz
+```
+
 
 ### Custom Installation
 

--- a/conjur-oss/files/conjur.conf
+++ b/conjur-oss/files/conjur.conf
@@ -22,7 +22,7 @@ server {
   }
 
   location / {
-    proxy_pass http://127.0.0.1:80;
+    proxy_pass http://127.0.0.1:8080;
   }
 }
 

--- a/conjur-oss/files/postgres-ssl.conf
+++ b/conjur-oss/files/postgres-ssl.conf
@@ -1,0 +1,5 @@
+ssl = on
+ssl_cert_file = '/opt/app-root/src/certificates/tls.crt'
+ssl_key_file = '/opt/app-root/src/certificates/tls.key'
+#ssl_ca_file = '/opt/app-root/src/certificates/ca.crt'
+#ssl_crl_file = '/opt/app-root/src/certificates/list.crl'

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- with .Values.deployment.annotations }}
+  annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
@@ -40,6 +41,7 @@ spec:
           secretName: {{ .Release.Name }}-conjur-ssl-ca-cert
           # Permission == 0400. JSON spec doesn't support octal notation.
           defaultMode: 256
+      {{- if not .Values.openshift.enabled }}
       - name: {{ .Release.Name }}-conjur-configmap-volume
         configMap:
           name: {{ .Release.Name }}-conjur-nginx-configmap
@@ -52,10 +54,14 @@ spec:
               path: dhparams.pem
             - key: conjur_site
               path: sites-enabled/conjur.conf
-
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-nginx
-        image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+        {{- if not .Values.openshift.enabled }}
+        image: "{{ .Values.nginx.image.kubernetes.repository }}:{{ .Values.nginx.image.kubernetes.tag }}"
+        {{- else }}
+        image: "{{ .Values.nginx.image.openshift.repository }}:{{ .Values.nginx.image.openshift.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
         ports:
         - containerPort: 9443
@@ -89,12 +95,18 @@ spec:
         - name: {{ .Release.Name }}-conjur-ssl-ca-cert-volume
           mountPath: /opt/conjur/etc/ssl/ca
           readOnly: true
+        {{- if not .Values.openshift.enabled }}
         - name: {{ .Release.Name }}-conjur-configmap-volume
           mountPath: /etc/nginx
           readOnly: true
+        {{- end }}
 
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- if not .Values.openshift.enabled }}
+        image: "{{ .Values.image.kubernetes.repository }}:{{ .Values.image.kubernetes.tag }}"
+        {{- else }}
+        image: "{{ .Values.image.openshift.repository }}:{{ .Values.image.openshift.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- if .Values.account.create }}
 {{- if .Release.IsUpgrade }}
@@ -110,12 +122,12 @@ spec:
 {{- end }}
         ports:
           - name: http
-            containerPort: 80
+            containerPort: 8080
             protocol: TCP
         livenessProbe:
           httpGet:
             path: /
-            port: 80
+            port: http
           initialDelaySeconds: 1
           periodSeconds: 5
           timeoutSeconds: 2
@@ -131,6 +143,8 @@ spec:
           # 1 seconds * 180 = 3 minutes
           failureThreshold: 180
         env:
+        - name: PORT
+          value: "8080"
         - name: CONJUR_AUTHENTICATORS
           valueFrom:
             secretKeyRef:

--- a/conjur-oss/templates/nginx-configmap.yaml
+++ b/conjur-oss/templates/nginx-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.openshift.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,3 +13,4 @@ data:
   mime_types: {{ tpl (.Files.Get "files/mime.types") . | quote }}
   conjur_site: {{ tpl (.Files.Get "files/conjur.conf") . | quote }}
   dhparams: {{ tpl (.Files.Get "files/dhparams.pem") . | quote }}
+{{- end -}}

--- a/conjur-oss/templates/postgres-ocp-ssl-configmap.yaml
+++ b/conjur-oss/templates/postgres-ocp-ssl-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.openshift.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-conjur-postgres-configmap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "conjur-oss.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  postgres_ssl: {{ tpl (.Files.Get "files/postgres-ssl.conf") . | quote }}
+{{- end -}}

--- a/conjur-oss/templates/postgres-ocp.yaml
+++ b/conjur-oss/templates/postgres-ocp.yaml
@@ -1,0 +1,104 @@
+{{- if and (.Values.openshift.enabled) (eq .Values.database.url "")}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
+  name: {{ .Release.Name }}-postgres
+  labels: &AppPostgresServiceLabels
+    app: {{ template "conjur-oss.name" . }}-postgres
+    chart: {{ template "conjur-oss.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.postgresLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - name: postgresql
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector: *AppPostgresServiceLabels
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-postgres
+  labels: &AppPostgresLabels
+    app: {{ template "conjur-oss.name" . }}-postgres
+    chart: {{ template "conjur-oss.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.postgresLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  serviceName: {{ .Release.Name }}-postgres
+  replicas: 1
+  selector:
+    matchLabels: *AppPostgresLabels
+  template:
+    metadata:
+      labels: *AppPostgresLabels
+    spec:
+      containers:
+      - image: "{{ .Values.postgres.image.openshift.repository }}:{{ .Values.postgres.image.openshift.tag }}"
+        imagePullPolicy: IfNotPresent
+        name: postgresql
+        env:
+        - name: POSTGRESQL_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-conjur-database-password
+              key: key
+        livenessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+            - --live
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        securityContext:
+          capabilities: {}
+          privileged: false
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        {{ if .Values.postgres.persistentVolume.create }}
+        - name: postgresql-data
+          mountPath: /var/lib/pgsql/data
+        {{- end }}
+        - name: ssl-certs
+          mountPath: "/opt/app-root/src/certificates"
+          readOnly: true
+        - name: {{ .Release.Name }}-conjur-postgres-configmap-volume
+          mountPath: /opt/app-root/src/postgresql-cfg
+          readOnly: true
+      volumes:
+      {{ if .Values.postgres.persistentVolume.create }}
+      - name: postgresql-data
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-conjur-oss-pvc
+      {{- end }}
+      - name: ssl-certs
+        secret:
+          secretName: {{ .Release.Name }}-conjur-database-ssl
+        # Set file permissions to 0600 (which corresponds to 384 decimal)
+          defaultMode: 384
+      - name: {{ .Release.Name }}-conjur-postgres-configmap-volume
+        configMap:
+          name: {{ .Release.Name }}-conjur-postgres-configmap
+          items:
+            - key: postgres_ssl
+              path: postgres-ssl.conf
+{{- end }}

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database.url "" }}
+{{- if and (not .Values.openshift.enabled) (eq .Values.database.url "")}}
 ---
 apiVersion: v1
 kind: Service
@@ -47,7 +47,7 @@ spec:
       securityContext:
         fsGroup: 999
       containers:
-      - image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+      - image: "{{ .Values.postgres.image.kubernetes.repository }}:{{ .Values.postgres.image.kubernetes.tag }}"
         imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
         name: postgres
         args: ["-c", "ssl=on", "-c", "ssl_cert_file=/etc/certs/tls.crt", "-c", "ssl_key_file=/etc/certs/tls.key"]

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -71,24 +71,8 @@
     },
     "image": {
       "properties": {
-        "pullPolicy": {
-          "type": "string"
-        },
-        "repository": {
-          "type": "string"
-        },
-        "tag": {
-          "type": "string"
-       }
-      }
-    },
-    "nginx": {
-      "properties": {
-        "image": {
+        "kubernetes": {
           "properties": {
-            "pullPolicy": {
-              "type": "string"
-            },
             "repository": {
               "type": "string"
             },
@@ -96,9 +80,51 @@
               "type": "string"
             }
           }
+        },
+        "openshift": {
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "pullPolicy": {
+          "type": "string"
         }
       }
     },
+    "nginx": {
+      "properties": {
+        "image": {
+          "properties": {
+            "kubernetes": {
+              "properties": {
+                "repository": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            },
+            "openshift": {
+              "properties": {
+                "repository": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            },
+            "pullPolicy": {
+              "type": "string"
+            }
+          }
+        },
     "nodeSelector": {
       "type": "object"
     },
@@ -106,13 +132,27 @@
       "properties": {
         "image": {
           "properties": {
+            "kubernetes": {
+              "properties": {
+                "repository": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            },
+            "openshift": {
+              "properties": {
+                "repository": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            },
             "pullPolicy": {
-              "type": "string"
-            },
-            "repository": {
-              "type": "string"
-            },
-            "tag": {
               "type": "string"
             }
           }
@@ -243,6 +283,15 @@
       "items": {
         "type": "string"
       }
+    },
+    "openshift": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
     }
   }
+}
+}
 }

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -62,25 +62,38 @@ deployment:
   annotations: {}
 
 image:
+  kubernetes:
+    repository: cyberark/conjur  # https://hub.docker.com/r/cyberark/conjur/
+    tag: '1.11.1'
+  openshift:
+    repository: registry.connect.redhat.com/cyberark/conjur
+    tag: latest
   pullPolicy: Always
-  repository: cyberark/conjur  # https://hub.docker.com/r/cyberark/conjur/
-  tag: '1.11.1'
 
 nginx:
   image:
+    kubernetes:
+      repository: nginx          # https://hub.docker.com/_/nginx/
+      tag: '1.15'
+    openshift:
+      repository: registry.connect.redhat.com/cyberark/conjur-nginx
+      tag: latest
     pullPolicy: Always
-    repository: nginx          # https://hub.docker.com/_/nginx/
-    tag: '1.15'
-
+      
 # nodeSelector (node selection constraints) to apply to the Conjur pod. Refer to:
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 nodeSelector: {}
 
 postgres:
   image:
+    kubernetes:
+      repository: postgres       # https://hub.docker.com/_/postgres/
+      tag: '10.14'
+    openshift:
+      repository: registry.redhat.io/rhscl/postgresql-10-rhel7      # https://catalog.redhat.com/software/containers/rhscl/postgresql-10-rhel7/5aa63541ac3db95f196086f1?container-tabs=overview
+      tag: latest
     pullPolicy: Always
-    repository: postgres       # https://hub.docker.com/_/postgres/
-    tag: '10.14'
+      
   persistentVolume:
     create: true
     size: 8Gi
@@ -168,3 +181,7 @@ serviceAccount:
 # scheduler which nodes should be avoided for Conjur pod placement. See:
 # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
 tolerations: []
+
+# Set enabled true for OCP support
+openshift: 
+  enabled: false


### PR DESCRIPTION
### What does this PR do?
- Add support for helm chart installation on OCP

### What ticket does this PR close?
Resolves #60 

### What has been changed 
- Add Postgres OCP Service, StatefulSet, ConfigMap and SSL config file
- Edit deployment.yml to run conjur image on port 8080 (80 is prohibited on OCP)
- Edit deployment.yml to use container-dap Conjur and Nginx images for OCP
- Edit values.yml to include openshift section that can be run using `openshift.enabled=true `

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Not needed for this effort but related 
- [x] Push the new Conjur and Nginx images to the RedHat catalog for enabling operator deployment

#### TODO
- [x] Make a new Conjur and Nginx image based on the container-dap repo and publish it to CyberArk docker hub

 