### PR TITLE
A POC that works in Openshift

### DIFF
--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -36,18 +36,18 @@ spec:
           secretName: {{ .Release.Name }}-conjur-ssl-ca-cert
           # Permission == 0400. JSON spec doesn’t support octal notation.
           defaultMode: 256
-      - name: {{ .Release.Name }}-conjur-configmap-volume
-        configMap:
-          name: {{ .Release.Name }}-conjur-nginx-configmap
-          items:
-            - key: nginx_conf
-              path: nginx.conf
-            - key: mime_types
-              path: mime.types
-            - key: dhparams
-              path: dhparams.pem
-            - key: conjur_site
-              path: sites-enabled/conjur.conf
+#      - name: {{ .Release.Name }}-conjur-configmap-volume
+#        configMap:
+#          name: {{ .Release.Name }}-conjur-nginx-configmap
+#          items:
+#            - key: nginx_conf
+#              path: nginx.conf
+#            - key: mime_types
+#              path: mime.types
+#            - key: dhparams
+#              path: dhparams.pem
+#            - key: conjur_site
+#              path: sites-enabled/conjur.conf
 
       containers:
       - name: {{ .Release.Name }}-nginx
@@ -85,22 +85,22 @@ spec:
         - name: {{ .Release.Name }}-conjur-ssl-ca-cert-volume
           mountPath: /opt/conjur/etc/ssl/ca
           readOnly: true
-        - name: {{ .Release.Name }}-conjur-configmap-volume
-          mountPath: /etc/nginx
-          readOnly: true
+#        - name: {{ .Release.Name }}-conjur-configmap-volume
+#          mountPath: /etc/nginx
+#          readOnly: true
 
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: ["server"]
+        args: ["server", "--port=8080"]
         ports:
           - name: http
-            containerPort: 80
+            containerPort: 8080
             protocol: TCP
         livenessProbe:
           httpGet:
             path: /
-            port: 80
+            port: http
           initialDelaySeconds: 1
           periodSeconds: 5
           timeoutSeconds: 2

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -67,10 +67,6 @@
         },
         "repository": {
           "type": "string"
-        },
-        "tag": {
-          "type": [ "string", "number" ],
-          "pattern": "(^\\d+(\\.\\d+){0,2})$"
         }
       }
     },
@@ -83,10 +79,6 @@
             },
             "repository": {
               "type": "string"
-            },
-            "tag": {
-              "type": [ "string", "number" ],
-              "pattern": "(^\\d+(\\.\\d+){0,2})$"
             }
           }
         }
@@ -104,10 +96,6 @@
             },
             "repository": {
               "type": "string"
-            },
-            "tag": {
-              "type": [ "string", "number" ],
-              "pattern": "(^\\d+(\\.\\d+){0,2})$"
             }
           }
         },


### PR DESCRIPTION
This branch works in OpenShift. It also explores relying on the Bitnami Postgres chart as opposed to rolling our own.
Below are the steps to deploy Postgres then Conjur:
```
# install Postgres first
PG_PASSWORD=0mbkLSg9ah
PG_NAMESPACE=my-pg-namespace

helm install my-release bitnami/postgresql
kubectl create namespace "${PG_NAMESPACE}"
helm install \
  -n "${PG_NAMESPACE}" \
  --set persistence.enabled="false" \
  --set volumePermissions.securityContext.runAsUser="auto" \
  --set securityContext.enabled=false \
  --set postgresqlPassword=${PG_PASSWORD} \
  --set containerSecurityContext.enabled=false \
  --set shmVolume.chmod.enabled=false \
  my-release bitnami/postgresql


# DATA_KEY can also be generated with DATA_KEY="$(docker run --rm cyberark/conjur data-key generate)"
DATA_KEY="UYyZPDWngzZ9o3eC5+eGGowNofXfSXfKRvqjsaf2FH4=
CONJUR_NAMESPACE=my-conjur-namespace

kubectl create namespace "${CONJUR_NAMESPACE}"
helm install \
   -n "${CONJUR_NAMESPACE}" \
   --set dataKey="${DATA_KEY}" \
   --set image.repository=guygiat/conjur-oss-ocp \
   --set image.tag=latest \
   --set image.pullPolicy=IfNotPresent \
   --set nginx.image.repository=guygiat/nginx-oss \
   --set nginx.image.tag=latest \
   --set nginx.image.pullPolicy=IfNotPresent \
   --set database.url=postgres://postgres:${PG_PASSWORD}@my-release-postgresql.${PG_NAMESPACE}.svc.cluster.local:5432/postgres \
   conjur-oss .
```