### PR TITLE
Add automatic Conjur account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `CONJUR_LOG_LEVEL` for the Conjur container can now be configured by setting the
   `logLevel` value, or updated using `helm upgrade` [cyberark/conjur-oss-helm-chart#77](https://github.com/cyberark/conjur-oss-helm-chart/issues/77)
 
+### Changed
+- `account` now accepts two values, `account.create`, a boolean, and `account.name`, a string. 
+  These values allow you to configure the creation of a Conjur account on container startup, and 
+  the name of the account. [cyberark/conjur-oss-helm-chart#77](https://github.com/cyberark/conjur-oss-helm-chart/issues/78)
+
 ## [v2.0.0] - 2020-06-18
 
 ### Added

--- a/conjur-oss/UPGRADING.md
+++ b/conjur-oss/UPGRADING.md
@@ -332,7 +332,7 @@ The restore operation to the new Conjur OSS deployment involves:
   simplicity in these instructions.
 
   The Helm values that are included in the migration described here:
-  - `account`
+  - `account.name`
   - `authenticators`
   - `database.password`
   - `database.url`
@@ -364,7 +364,7 @@ $  namespace="<conjur-namespace>"
 
 $  helm_chart_name=$(helm list -n "$namespace" -q)
 $  account=$(helm show values "$helm_chart_name" | \
-             awk '/^account:/{print $2}' | \
+             awk '/^account\.name:/{print $2}' | \
              sed -e 's/^"//' -e 's/"$//')
 $  authenticators=$(kubectl get secret \
              -n "$namespace" \
@@ -440,7 +440,7 @@ $  namespace="<conjur-namespace>"
 $  helm_chart_name=conjur-oss
 $  helm install \
         -n "$namespace" \
-        --set account="$account" \
+        --set account.name="$account" \
         --set authenticators="$authenticators" \
         --set database.password="$db_password" \
         --set dataKey="$data_key" \
@@ -511,7 +511,7 @@ $  namespace="<conjur-namespace>"
 
 $  helm_chart_name=$(helm list -n "$namespace" -q)
 $  account=$(helm show values "$helm_chart_name" | \
-             awk '/^account:/{print $2}' | \
+             awk '/^account\.name:/{print $2}' | \
              sed -e 's/^"//' -e 's/"$//')
 $  authenticators=$(kubectl get secret \
              -n "$namespace" \
@@ -551,7 +551,7 @@ $  namespace="<conjur-namespace>"
 $  helm_chart_name=conjur-oss
 $  helm install \
         -n "$namespace" \
-        --set account="$account" \
+        --set account.name="$account" \
         --set authenticators="$authenticators" \
         --set database.url="$db_url" \
         --set dataKey="$data_key" \

--- a/conjur-oss/templates/NOTES.txt
+++ b/conjur-oss/templates/NOTES.txt
@@ -37,7 +37,24 @@
         /etc/hosts file: "$SERVICE_IP  {{ $.Values.ssl.hostname }}"
 {{- end }}
 
-2. Configure Conjur
+{{ if .Values.account.create }}
+2. Configure Conjur Account
+
+  To retrieve the credentials for the account created in Conjur at startup, {{ .Values.account.name | quote }}
+  , use the following commands: 
+
+      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} \
+                                         -l "app={{ template "conjur-oss.name" . }},release={{ .Release.Name }}" \
+                                         -o jsonpath="{.items[0].metadata.name}")
+      kubectl exec --namespace {{ .Release.Namespace }} \
+                   $POD_NAME \
+                   --container={{ .Chart.Name }} \
+                   -- conjurctl role retrieve-key {{ .Values.account.name }}:user:admin
+
+  Back up this key in a safe location.
+{{- else }}
+2. Configure Conjur Account
+
   To create an initial account and login, follow the instructions here:
   https://www.conjur.org/get-started/install-conjur.html#install-and-configure
 
@@ -47,13 +64,15 @@
       kubectl exec --namespace {{ .Release.Namespace }} \
                    $POD_NAME \
                    --container={{ .Chart.Name }} \
-                   -- conjurctl account create {{ .Values.account | quote }}
+                   -- conjurctl account create {{ .Values.account.name | quote }}
 
   Note that the conjurctl account create command gives you the
   public key and admin API key for the account administrator you created.
   Back them up in a safe location.
+{{- end }}
 
 3. Connect to Conjur
+
   Start a container with Conjur CLI and authenticate with the new user:
 
       docker run --rm -it --entrypoint bash cyberark/conjur-cli:5
@@ -65,7 +84,7 @@
       #       SSL certificate names otherwise SSL verification will fail and you will not
       #       be able to log in.
       # NOTE: Also ensure that the URL does not contain a slash (`/`) at the end of the URL
-      conjur init -u <ENDPOINT> -a {{ .Values.account | quote }}
+      conjur init -u <ENDPOINT> -a {{ .Values.account.name | quote }}
 
       # API key here is the key that creation of the account provided you in step #2
       conjur authn login -u admin -p <API_KEY>
@@ -75,4 +94,4 @@
 
 4. Next Steps
   - Go through the Conjur Tutorials: https://www.conjur.org/tutorials/
-  - View Conjur’s API Documentation: https://www.conjur.org/api.html
+  - View Conjur's API Documentation: https://www.conjur.org/api.html

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -92,7 +92,11 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.account.name }}
+        args: ["server", "--account={{ .Values.account.name }}"]
+{{ else }}
         args: ["server"]
+{{- end }}
         ports:
           - name: http
             containerPort: 80
@@ -132,7 +136,7 @@ spec:
               name: {{ .Release.Name }}-conjur-database-url
               key: key
         - name: CONJUR_ACCOUNT
-          value: {{ .Values.account }}
+          value: {{ .Values.account.name }}
         - name: CONJUR_LOG_LEVEL
           value: {{ .Values.logLevel }}
         resources:

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -5,7 +5,16 @@
   ],
   "properties": {
     "account": {
-      "type": "string"
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     },
     "affinity": {
       "type": "object"

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -8,10 +8,13 @@
 # risk of leaving around residual values files containing this sensitive
 # information.
 
-
-# Name of Conjur account to be created. Maps to CONJUR_ACCOUNT env variable
-# for the Conjur container.
-account: "default"
+account:
+  # Name of Conjur account to be created. Maps to CONJUR_ACCOUNT env variable
+  # for the Conjur container.
+  name: "default"
+  # Set to 'true' to allow the Conjur server to automatically create an account
+  # with the configured account.name.
+  create: false
 
 # Affinity rules to apply to the Conjur pod to indicate to Kubernetes scheduler
 # which nodes would be most appropriate for Conjur pod placement. See:


### PR DESCRIPTION
### What does this PR do?
The `account` value has been changed to an object, containing two sub-types, `account.create` 
and `account.name`. These parameters will dictate that a Conjur account should be created on startup, 
and what the name of the account will be, respectively.

### What ticket does this PR close?
Resolves #78 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation