### PR TITLE
adding help support to connect to external DB with password

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -418,7 +418,7 @@ The Kubernetes secrets that may need to be manually deleted following
 |Secret Name|Description|When is Manual Deletion Required?|
 |-----------|-----------|---------------------------------|
 |`<helm-release>-conjur-database-password`|Database Password|When created (i.e. database URL not explicitly set)|
-|`<helm-release>-remote-database-password`|Remote Database Password|When created (i.e. database URL not explicitly set)|
+|`<helm-release>-database-remote-password`|Remote Database Password|When created (i.e. database URL not explicitly set)|
 |`<helm-release>-conjur-database-ssl`|Database SSL Certificate|When auto-generated (i.e. not explicitly set)|
 |`<helm-release>-conjur-database-url`|Database URL|When auto-generated (i.e. not explicitly set)|
 |`<helm-release>-conjur-data-key`|Data encryption key|Always|

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -39,7 +39,7 @@ Conjur Open Source is part of the CyberArk Privileged Access Security Solution w
   recommended in order to facilitate limiting of direct access to Conjur
   Kubernetes resources to security administrators. Here, the term isolated
   refers to:
-  * No workloads besides Conjur and its backend database running in the 
+  * No workloads besides Conjur and its backend database running in the
     Kubernetes cluster/namespace.
   * Kubernetes and Helm access to the cluster/namespace is limited to
     security administrators via Role-Based Access Control (RBAC).
@@ -231,7 +231,7 @@ automatic generation of the following configuration:
 
 - Postgres database SSL certificate and key (for integrated Postgres
   database only).
-  
+
   Alternatively, these values can be set explicitly with the following
   `helm install` arguments (or by setting the equivalent field in a custom
   values.yaml file):
@@ -256,7 +256,7 @@ automatic generation of the following configuration:
 ## Upgrading, Modifying, or Migrating a Conjur OSS Helm Deployment
 
 This Helm chart supports modifications or upgrades of a Conjur deployment via the
-[helm upgrade](https://helm.sh/docs/helm/helm_upgrade/#helm) command. 
+[helm upgrade](https://helm.sh/docs/helm/helm_upgrade/#helm) command.
 This includes tasks such as rotating SSL certificates.
 
 For details on how to upgrade or modify an existing Conjur OSS Helm deployment,
@@ -266,9 +266,9 @@ separate Conjur OSS Helm deployment, please see the
 
 ### Modifying environment variables for an existing Conjur OSS Helm Deployment
 
-After deploying the Conjur OSS using the helm chart, you may need to add or modify an 
-environment variable within the Conjur container. This task can be performed without needing 
-to tear down your existing deployment by using the `helm upgrade` command. 
+After deploying the Conjur OSS using the helm chart, you may need to add or modify an
+environment variable within the Conjur container. This task can be performed without needing
+to tear down your existing deployment by using the `helm upgrade` command.
 
 #### Example: Changing Log Level
 
@@ -299,6 +299,7 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`conjurLabels`|Extra Kubernetes labels to apply to Conjur resources|`{}`|
 |`database.url`|PostgreSQL connection string. If left blank, an integrated PostgreSQL deployment is created.|`""`|
 |`database.password`|PostgreSQL database password string. Unused if an external Postgres database is configured. See [PostgreSQL Database Password Restrictions](#postgresql-database-password-restrictions) below.|`""`|
+|`database.remotePassword`|PostgreSQL database password string. Unused if an external Postgres database is configured. See [PostgreSQL Database Password Restrictions](#postgresql-database-password-restrictions) below.|`""`|
 |`database.ssl.Cert`|PostgreSQL TLS x509 certificate, base64 encoded.|`""`|
 |`database.ssl.key`|PostgreSQL TLS private key, base64 encoded.|`""`|
 |`dataKey`|Conjur data key, 32 byte base-64 encoded string for data encryption.|`""`|
@@ -335,7 +336,7 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 To display additional debugging information for the Conjur container,
 you can set the `logLevel` value to `debug`.
 
-To change this value without needing to re-deploy or modify your 
+To change this value without needing to re-deploy or modify your
 configuration, perform the following steps:
 
 1. Run `helm upgrade` to change the current debug value
@@ -371,7 +372,7 @@ $ kubectl logs $POD_NAME conjur-oss
 $ kubectl logs -f $POD_NAME conjur-oss
 ```
 
-### PostgreSQL Database Password Restrictions 
+### PostgreSQL Database Password Restrictions
 The following restrictions apply to the PostgreSQL database password:
 
 - Password must only contain the following:
@@ -417,6 +418,7 @@ The Kubernetes secrets that may need to be manually deleted following
 |Secret Name|Description|When is Manual Deletion Required?|
 |-----------|-----------|---------------------------------|
 |`<helm-release>-conjur-database-password`|Database Password|When created (i.e. database URL not explicitly set)|
+|`<helm-release>-remote-database-password`|Remote Database Password|When created (i.e. database URL not explicitly set)|
 |`<helm-release>-conjur-database-ssl`|Database SSL Certificate|When auto-generated (i.e. not explicitly set)|
 |`<helm-release>-conjur-database-url`|Database URL|When auto-generated (i.e. not explicitly set)|
 |`<helm-release>-conjur-data-key`|Data encryption key|Always|

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -131,6 +131,13 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-conjur-database-url
               key: key
+        {{ if .Values.database.remotePassword }}
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-database-remote-password
+              key: key
+        {{ end }}
         - name: CONJUR_ACCOUNT
           value: {{ .Values.account }}
         - name: CONJUR_LOG_LEVEL

--- a/conjur-oss/templates/secrets.yaml
+++ b/conjur-oss/templates/secrets.yaml
@@ -38,6 +38,29 @@ type: Opaque
 data:
   key: {{ .Values.dataKey | b64enc }}
 ---
+{{ if .Values.database.remotePassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-database-remote-password
+  labels:
+    app: {{ template "conjur-oss.name" . }}
+    chart: {{ template "conjur-oss.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/component: service
+{{- with .Values.conjurLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
+type: Opaque
+data:
+  key: {{ .Values.database.remotePassword | b64enc }}
+{{ end }}
+---
 {{- include "conjur-oss.database-password" . }}
 apiVersion: v1
 kind: Secret

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -34,6 +34,7 @@ database:
   # 64-character alphanumeric password will be auto-generated.
   # Note that this value will be ignored for Helm upgrade operations.
   password: ""
+  remotePassword: ""
 
   ssl:
     # Backend database SSL certificate and private key. These should be
@@ -103,7 +104,7 @@ replicaCount: 1
 # and resource quotas. The namespace-wide resource limitations are
 # typically set by a cluster administrator to values that make sense for
 # the host Kubernetes platform.
-# 
+#
 # If you do want to specify resources, uncomment the following lines, adjust
 # them as necessary, and remove the curly braces after 'resources:'.
 # limits:


### PR DESCRIPTION
### What does this PR do?
This PR provides possibility to configure postgres password for conjur to connect with DB
It was developed to support Aurora DB support for Dap NG
This is dove by adding database.remotePassword variable to helm chart of conjur-oss

#### Test coverage
Will be covered as part of DAP NG

