### PR TITLE
Remove need for '--recreate-pods`

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -282,7 +282,6 @@ $  LOG_LEVEL="<info, debug, etc.>
 $  helm upgrade \
    -n "$CONJUR_NAMESPACE" \
    --reuse-values \
-   --recreate-pods \
    --set logLevel="$LOG_LEVEL" \
    "$HELM_RELEASE" \
    ./conjur-oss
@@ -347,7 +346,6 @@ $  LOG_LEVEL="debug"
 $  helm upgrade \
    -n "$CONJUR_NAMESPACE" \
    --reuse-values \
-   --recreate-pods \
    --set logLevel="$LOG_LEVEL" \
    "$HELM_RELEASE" \
    ./conjur-oss

--- a/conjur-oss/UPGRADING.md
+++ b/conjur-oss/UPGRADING.md
@@ -90,7 +90,6 @@ $  HELM_RELEASE="conjur-oss"
 $  helm upgrade \
    -n "$CONJUR_NAMESPACE" \
    --reuse-values \
-   --recreate-pods \
    < INSERT YOUR --set CUSTOMIZATION SETTINGS HERE > \
    "$HELM_RELEASE" \
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v<VERSION>/conjur-oss-<VERSION>.tgz
@@ -105,7 +104,6 @@ $  HELM_RELEASE="conjur-oss"
 $  helm upgrade \
    -n "$CONJUR_NAMESPACE" \
    --reuse-values \
-   --recreate-pods \
    < INSERT YOUR --set CUSTOMIZATION SETTINGS HERE > \
    "$HELM_RELEASE" \
    ./conjur-oss
@@ -115,9 +113,6 @@ Some notes:
 
 - The `--reuse-values` is required to preserve any non-default values
   that were used during your previous `helm install`.
-- `--recreate-pods` is required to ensure that pods are using the latest
-  configuration from Kubernetes `secrets` and `configMaps` following
-  `helm upgrade`.
 - Custom values that can be set via `--set` are described in the
   [Custom Installation](README.md#custom-installation) section of the
   [README.md](README.md) file.
@@ -149,7 +144,6 @@ $  HELM_RELEASE="conjur-oss"
 $  helm upgrade \
    -n "$CONJUR_NAMESPACE" \
    --reuse-values \
-   --recreate-pods \
    --set image.tag="<new-conjur-version>" \
    "$HELM_RELEASE" \
    ./conjur-oss
@@ -166,7 +160,6 @@ $  HELM_RELEASE="conjur-oss"
 $  helm upgrade \
    -n "$CONJUR_NAMESPACE" \
    --reuse-values \
-   --recreate-pods \
    --set nginx.image.tag="<nginx-version>" \
    "$HELM_RELEASE" \
    ./conjur-oss
@@ -207,7 +200,6 @@ $  kubectl delete -n "$CONJUR_NAMESPACE" "$CERT_SECRET"
 $  helm upgrade \
        -n "$CONJUR_NAMESPACE" \
        --reuse-values \
-       --recreate-pods \
        --set database.ssl.cert="<new-ssl-cert>" \
        --set database.ssl.key="<new-ssl-key>" \
        "$HELM_RELEASE" \
@@ -255,7 +247,6 @@ $  kubectl delete -n "$CONJUR_NAMESPACE" "$CERT_SECRET"
 $  helm upgrade \
        -n "$CONJUR_NAMESPACE" \
        --reuse-values \
-       --recreate-pods \
        --set ssl.caCert="<new-ssl-CA-cert>" \
        --set ssl.caKey="<new-ssl-CA-key>" \
        --set ssl.cert="<new-ssl-cert>" \
@@ -283,7 +274,6 @@ $  HELM_RELEASE="conjur-oss"
 $  helm upgrade \
        -n "$CONJUR_NAMESPACE" \
        --reuse-values \
-       --recreate-pods \
        --set "database.url=<new-database-url>" \
        "$HELM_RELEASE" \
        ./conjur-oss
@@ -489,7 +479,6 @@ $  kubectl exec -it -n "$namespace" \
 ```sh-session
 $  helm upgrade -n "$namespace" \
                 --reuse-values \
-                --recreate-pods \
                 --set replicaCount="1" \
                 $helm_chart_name \
                 ./conjur-oss

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -13,7 +13,6 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- with .Values.deployment.annotations }}
-  annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
@@ -23,18 +22,23 @@ spec:
   template:
     metadata:
       labels: *AppConjurLabels
+      annotations:
+        # Automatically roll deployment if dependent secrets have been changed
+        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/ssl-cert.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "conjur-oss.service-account" . }}
       volumes:
       - name: {{ .Release.Name }}-conjur-ssl-cert-volume
         secret:
           secretName: {{ .Release.Name }}-conjur-ssl-cert
-          # Permission == 0400. JSON spec doesn’t support octal notation.
+          # Permission == 0400. JSON spec doesn't support octal notation.
           defaultMode: 256
       - name: {{ .Release.Name }}-conjur-ssl-ca-cert-volume
         secret:
           secretName: {{ .Release.Name }}-conjur-ssl-ca-cert
-          # Permission == 0400. JSON spec doesn’t support octal notation.
+          # Permission == 0400. JSON spec doesn't support octal notation.
           defaultMode: 256
       - name: {{ .Release.Name }}-conjur-configmap-volume
         configMap:

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -41,6 +41,8 @@ spec:
   template:
     metadata:
       labels: *AppPostgresLabels
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       securityContext:
         fsGroup: 999

--- a/helm-upgrade.sh
+++ b/helm-upgrade.sh
@@ -19,7 +19,7 @@ set -eo pipefail
 #
 # Also, force the recreation of pods, since Helm isn't aware that pods need
 # to be started e.g. for when configmaps or secrets are changed.
-HELM_ARGS="$@ --reuse-values --recreate-pods"
+HELM_ARGS="$@ --reuse-values"
 
 if [ ! -z "$CONJUR_NAMESPACE" ]; then
   HELM_ARGS="$HELM_ARGS -n $CONJUR_NAMESPACE"


### PR DESCRIPTION
### What does this PR do?
Using the `checksum/config` annotation, we can
automatically cause pods to recreate if their checksum
changes. This allows us to remove `--recreate-pods`
from our instructions, as the command is deprecated.

### What ticket does this PR close?
-

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation