### PR TITLE
Auto create should depend on account.create and upgrades should work

### DIFF
--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -92,8 +92,15 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.account.name }}
+{{- if .Values.account.create }}
+{{- if .Release.IsUpgrade }}
+        # For Helm upgrade, we want to make server startup idempotent, i.e.
+        # tolerant of the chart setting 'account.create=true' being reused.
+        command: ["bash"]
+        args: ["-c", "conjurctl server --account={{ .Values.account.name }} || conjurctl server"]
+{{ else }}
         args: ["server", "--account={{ .Values.account.name }}"]
+{{- end }}
 {{ else }}
         args: ["server"]
 {{- end }}


### PR DESCRIPTION
### What does this PR do?
This change addresses a couple of issues:

- Automatic creation of a Conjur account depends upon whether or not
  `account.name` is set, rather than `account.create`.
- If a Conjur account has been automatically created, Helm upgrades
  are currently failing with the following error:
  ```
  Account 'myConjurAccount' already exists
  error: exit
  ```
### What ticket does this PR close?
Resolves #90 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation