### PR TITLE
Adjust instructions for retrieving API key

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -209,8 +209,11 @@ POD_NAME=$(kubectl get pods --namespace "$CONJUR_NAMESPACE" \
 kubectl exec --namespace "$CONJUR_NAMESPACE" \
             "$POD_NAME" \
             --container=conjur-oss \
-            -- conjurctl role retrieve-key "$ACCOUNT_NAME":user:admin
+            -- conjurctl role retrieve-key "$ACCOUNT_NAME":user:admin | tail -1
 ```
+
+> Note: If you have `logLevel` set to `debug`, the `tail -1` command will truncate the output.
+To see all output, remove this additional command from the end.
 
 If you set `account.create` to `false`, or did not provide a value, an admin account will
 need to be created. To create an account, use the following commands:
@@ -223,7 +226,7 @@ POD_NAME=$(kubectl get pods --namespace "$CONJUR_NAMESPACE" \
 kubectl exec --namespace $CONJUR_NAMESPACE \
               $POD_NAME \
               --container=conjur-oss \
-              -- conjurctl account create $ACCOUNT_NAME
+              -- conjurctl account create $ACCOUNT_NAME | tail -1
 ```
 The credentials for this account will be provided after the account has been created.
 Store these in a safe location.

--- a/conjur-oss/templates/NOTES.txt
+++ b/conjur-oss/templates/NOTES.txt
@@ -49,7 +49,7 @@
       kubectl exec --namespace {{ .Release.Namespace }} \
                    $POD_NAME \
                    --container={{ .Chart.Name }} \
-                   -- conjurctl role retrieve-key {{ .Values.account.name }}:user:admin
+                   -- conjurctl role retrieve-key {{ .Values.account.name }}:user:admin | tail -1
 
   Back up this key in a safe location.
 {{- else }}
@@ -64,7 +64,7 @@
       kubectl exec --namespace {{ .Release.Namespace }} \
                    $POD_NAME \
                    --container={{ .Chart.Name }} \
-                   -- conjurctl account create {{ .Values.account.name | quote }}
+                   -- conjurctl account create {{ .Values.account.name | quote }} | tail -1
 
   Note that the conjurctl account create command gives you the
   public key and admin API key for the account administrator you created.


### PR DESCRIPTION
### What does this PR do?
`tail -1` was added to the end of each instruction
related to account creation and key retrieval.
This has been tested to show that the last line of
these commands will always display the key, or the
line containing the key.

### What ticket does this PR close?
Resolves #92 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation