### PR TITLE
Deprecates creation of ClusterRoleBinding by default

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -352,7 +352,7 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`postgres.persistentVolume.create`|Create a peristent volume to back the PostgreSQL data|`true`|
 |`postgres.persistentVolume.size`|Size of persistent volume to be created for PostgreSQL|`"8Gi"`|
 |`postgres.persistentVolume.storageClass`|Storage class to be used for PostgreSQL persistent volume claim|`nil`|
-|`rbac.create`|Controls whether or not RBAC resources are created|`true`|
+|`rbac.create`|Controls whether or not RBAC resources are created. This setting is deprecated and will be replaced in the next major release with two separate settings: `rbac.createClusterRole` (defaulting to true) and `rbac.createClusterRoleBinding` (defaulting to false), and the creation of RoleBindings will be recommended over relying on this ClusterRoleBinding.|`true`|
 |`replicaCount`|Number of desired Conjur pods|`1`|
 |`service.external.annotations`|Annotations for the external LoadBalancer|`[service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp]`|
 |`service.external.enabled`|Expose service to the Internet|`true`|

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -94,6 +94,14 @@ postgresLabels: {}
 # created. This should be set to true, unless there is already a Conjur
 # deployment in a separate namespace that has already created these
 # cluster-wide resources.
+#
+# NOTE: This setting is deprecated and will be replaced in the next major
+# release with two separate settings:
+#   - rbac.createClusterRole        (defaulting to true)
+#   - rbac.createClusterRoleBinding (defaulting to false)
+# and the recommendation will be for chart users to create RoleBindings
+# for each individual namespace that supports applications that require
+# Conjur Kubernetes authentication.
 rbac:
   create: true
 


### PR DESCRIPTION
### What does this PR do?

The current Conjur OSS Helm chart templates include the creation of both
a Kubernetes ClusterRole and a ClusterRoleBinding. The intent of the
ClusterRoleBinding is to grant RBAC permissions (across all namespaces) for
the Conjur's Kubernetes authenticator plugin (authn-k8s).

A better approach is to not use a ClusterRoleBinding (which applies across
all namespaces), and instead rely upon users to create namespace-scoped
RoleBindings for those namespaces that have applications that require
authn-k8s authentication.

This change adds deprecation warnings in the chart README.md and in
the charts values.yaml file indicating that the rbac.create chart
value is being deprecated and will be replace by 2 separate setting
in the next major release:
    - rbac.createClusterRole         (defaulting to true)
    - rbac.createClusterRoleBinding  (defaulting to false)

### What ticket does this PR close?
Resolves #95

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation