### PR TITLE
Add internal registry to KinD example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ values-private.yaml
 
 # Vim swapfiles
 *.sw[po]
+
+# Example temp files
+examples/kubernetes-in-docker/temp*

--- a/examples/kubernetes-in-docker/0_export_env_vars.sh
+++ b/examples/kubernetes-in-docker/0_export_env_vars.sh
@@ -25,9 +25,12 @@ export TEST_APP_LOADBALANCER_SVCS="${TEST_APP_LOADBALANCER_SVCS:-false}"
 # build and push demo images to a registry so that the images can then be
 # pulled by KinD.
 #
-# These should be configured/customized in bootstrap.env
-check_env_var "DOCKER_REGISTRY_URL"
-check_env_var "DOCKER_REGISTRY_PATH"
-check_env_var "DOCKER_USERNAME"
-check_env_var "DOCKER_PASSWORD"
-check_env_var "DOCKER_EMAIL"
+# These should be configured/customized in customize.env
+export CREATE_DOCKER_INTERNAL_REGISTRY="${CREATE_DOCKER_INTERNAL_REGISTRY:-true}"
+if [[ "CREATE_DOCKER_INTERNAL_REGISTRY" == "false" ]]; then
+  check_env_var "DOCKER_REGISTRY_URL"
+  check_env_var "DOCKER_REGISTRY_PATH"
+  check_env_var "DOCKER_USERNAME"
+  check_env_var "DOCKER_PASSWORD"
+  check_env_var "DOCKER_EMAIL"
+fi

--- a/examples/kubernetes-in-docker/1_create_kind_cluster.sh
+++ b/examples/kubernetes-in-docker/1_create_kind_cluster.sh
@@ -24,6 +24,33 @@ fi
 # Check if KinD cluster has already been created
 if [ "$(kind get clusters | grep "^$KIND_CLUSTER_NAME$")" = "$KIND_CLUSTER_NAME" ]; then
   echo "KinD cluster '$KIND_CLUSTER_NAME' already exists. Skipping cluster creation."
+elif [[ $CREATE_DOCKER_INTERNAL_REGISTRY == "true" ]]; then 
+  announce "Creating KinD Cluster with local registry"
+  
+  reg_name='kind-registry'
+  reg_port='5000'
+    
+  # create registry container unless it already exists
+  running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+  if [ "${running}" != 'true' ]; then
+    docker run \
+      -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" --net=kind \
+      registry:2
+  fi
+  reg_ip="$(docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "${reg_name}")"
+  echo "Registry IP: ${reg_ip}"
+
+  # create a cluster with the local registry enabled in containerd
+  cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches: 
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_ip}:${reg_port}"]
+EOF
+
+  export DOCKER_REGISTRY_URL="${reg_ip}:${reg_port}"
 else
   kind create cluster --name "$KIND_CLUSTER_NAME"
 fi

--- a/examples/kubernetes-in-docker/customize.env
+++ b/examples/kubernetes-in-docker/customize.env
@@ -3,19 +3,20 @@
 # Uncomment and modify the settings below, and source the resulting file
 # to customize the demo scripts that are in this directory.
 #
-# NOTE: The DOCKER settings below are required to run the test scripts,
-# so at a minimum these environment settings must be changed.
+# NOTE: The DOCKER settings below are required, unless CREATE_DOCKER_INTERNAL_REGISTRY
+# is set to "true"
 
-# CHANGE THE FOLLOWING DOCKER CREDENTIAL ENVIRONMENT VARIABLES!!!
-# Docker registry credentials are required since the demo scripts need to
-# build and push demo images to a registry so that the images can then be
-# pulled by KinD. For example, if you are using your personal DockerHub
+# Docker registry credentials are need to build and push demo images 
+# to a registry so that the images can then be pulled by KinD. 
+# For example, if you are using your personal DockerHub
 # account, your environment settings might look something like this:
+#     export CREATE_DOCKER_INTERNAL_REGISTRY="false"
 #     export DOCKER_REGISTRY_URL="docker.io"
 #     export DOCKER_REGISTRY_PATH="firstnamelastname"
 #     export DOCKER_USERNAME="firstnamelastname"
 #     export DOCKER_PASSWORD="GreatGooglyMoogly"
 #     export DOCKER_EMAIL="firstname.lastname@example.com"
+#export CREATE_DOCKER_INTERNAL_REGISTRY="true"
 #export DOCKER_REGISTRY_URL="docker.io"
 #export DOCKER_REGISTRY_PATH="<your-dockerhub-org-or-username>"
 #export DOCKER_USERNAME="<your-dockerhub-username>"


### PR DESCRIPTION
### What does this PR do?
By default, our KinD example now will create a  internal registry, then export the URL to be used by
our kubernetes demo when pulling and pushing images

### What ticket does this PR close?
~

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation