### PR TITLE
Miscellaneous cleanup for KinD example

### DIFF
--- a/examples/kubernetes-in-docker/0_export_env_vars.sh
+++ b/examples/kubernetes-in-docker/0_export_env_vars.sh
@@ -21,13 +21,17 @@ export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
 # KinD specific specific setting for demo scripts
 export TEST_APP_LOADBALANCER_SVCS="${TEST_APP_LOADBALANCER_SVCS:-false}"
 
-# DockerHub account credentials are required since the demo scripts need to
-# build and push demo images to a registry so that the images can then be
-# pulled by KinD.
+# You can choose to have the scripts create a local, insecure Docker registry
+# for pushing/pulling pod images by exporting the following:
+#     export USE_DOCKER_LOCAL_REGISTRY=true
+# Or you can use a public Docker registry (e.g. DockerHub) by exporting
+# your Docker credentials.
 #
-# These should be configured/customized in customize.env
+# These can be configured/customized in customize.env
 export USE_DOCKER_LOCAL_REGISTRY="${USE_DOCKER_LOCAL_REGISTRY:-true}"
-export DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-localhost:5000}"
+export DOCKER_LOCAL_REGISTRY_NAME="${DOCKER_LOCAL_REGISTRY_NAME:-kind-registry}"
+export DOCKER_LOCAL_REGISTRY_PORT="${DOCKER_LOCAL_REGISTRY_PORT:-5000}"
+export DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL:-localhost:$DOCKER_LOCAL_REGISTRY_PORT}"
 if [[ "USE_DOCKER_LOCAL_REGISTRY" == "false" ]]; then
   check_env_var "DOCKER_REGISTRY_URL"
   check_env_var "DOCKER_REGISTRY_PATH"

--- a/examples/kubernetes-in-docker/2_helm_install_or_upgrade_conjur.sh
+++ b/examples/kubernetes-in-docker/2_helm_install_or_upgrade_conjur.sh
@@ -35,13 +35,11 @@ if [ "$(helm list -q -n $CONJUR_NAMESPACE | grep "^$HELM_RELEASE$")" = "$HELM_RE
       --set authenticators="authn\,authn-k8s/$AUTHENTICATOR_ID" \
       --set logLevel="$CONJUR_LOG_LEVEL" \
       --reuse-values \
-      --recreate-pods \
       "$HELM_RELEASE" \
       "../../conjur-oss"
 else
   # Helm install a Conjur cluster and create a Conjur account
   data_key="$(docker run --rm cyberark/conjur data-key generate)"
-  echo "data_key: $data_key"
   helm install \
       -n "$CONJUR_NAMESPACE" \
       --set dataKey="$data_key" \

--- a/examples/kubernetes-in-docker/4_ensure_authn_k8s_enabled.sh
+++ b/examples/kubernetes-in-docker/4_ensure_authn_k8s_enabled.sh
@@ -14,7 +14,6 @@ if grep -q "$authenticators" <<< "$AUTHENTICATOR_ID"; then
   helm upgrade \
        -n "$CONJUR_NAMESPACE" \
        --reuse-values \
-       --recreate-pods \
        --set authenticators="authn\,authn-k8s/$AUTHENTICATOR_ID" \
        --set logLevel="$CONJUR_LOG_LEVEL" \
        "$HELM_RELEASE" \

--- a/examples/kubernetes-in-docker/README.md
+++ b/examples/kubernetes-in-docker/README.md
@@ -166,14 +166,20 @@ demo scripts are run. You can do this by either modifying the existing
 `customize.env` file, or creating your own copy to modify and using
 the `-c <customization-file>` command line argument for the `start` script.
 
-#### Providing Docker Registry Credentials
+#### Configuring a Docker Registry
 
-Because the Kubernetes Conjur Demo scripts build and push several demo
-container images to a Docker registry, you will need to provide Docker
-registry credentials for the scripts to use.
+Kubernetes Conjur Demo scripts build and push several demo container images
+to a Docker registry so that they can then be pulled by KinD. You can choose
+to have the scripts create and use a local, insecure Docker registry
+by exporting the following:
 
-This is done by uncommenting the following lines in `customize.env`
-and substituting your Docker credentials:
+```
+     export USE_DOCKER_LOCAL_REGISTRY=true
+```
+
+Or you can use a public Docker registry (e.g. DockerHub) by providing
+your Docker credentials. This is done by uncommenting the following lines
+in `customize.env` and substituting your Docker credentials:
 
 ```
 #export DOCKER_REGISTRY_URL="docker.io"
@@ -288,7 +294,6 @@ HELM_RELEASE=conjur-oss
 helm upgrade \
      -n "$CONJUR_NAMESPACE" \
      --reuse-values \
-     --recreate-pods \
      --set logLevel=debug \
      "$HELM_RELEASE" \
      ./conjur-oss

--- a/examples/kubernetes-in-docker/customize.env
+++ b/examples/kubernetes-in-docker/customize.env
@@ -6,10 +6,11 @@
 # NOTE: The DOCKER settings below are required, unless USE_DOCKER_LOCAL_REGISTRY
 # is set to "true"
 
-# Docker registry credentials are need to build and push demo images 
-# to a registry so that the images can then be pulled by KinD. 
-# For example, if you are using your personal DockerHub
-# account, your environment settings might look something like this:
+# You can choose to have the scripts create a local, insecure Docker registry
+# for pushing/pulling pod images by exporting the following:
+#     export USE_DOCKER_LOCAL_REGISTRY=true
+# Or you can use a public Docker registry (e.g. DockerHub) by exporting
+# your Docker credentials, which might look something like this:
 #     export USE_DOCKER_LOCAL_REGISTRY="false"
 #     export DOCKER_REGISTRY_URL="docker.io"
 #     export DOCKER_REGISTRY_PATH="firstnamelastname"


### PR DESCRIPTION
- Parameterized local Docker registry name and port as env vars just in
  case someone has a conflict.
- If KinD cluster is already running, and USE_DOCKER_LOCAL_REGISTRY is
  set to 'true', check that the registry is already running, or else
  exit with an error that the KinD cluster needs to be recreated.
- Delete instances of '--recreate-pods' flag.
- Deleted this export in 1_create_kind_cluster since it shouldn't have
  any effect (it's not sourced by the parent `start` script):
       export DOCKER_REGISTRY_URL="${reg_ip}:${reg_port}"
- Updated some comments re. use of local Docker registry in example's
  README.md and in some scripts.

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation