### PR TITLE
Adds waits for helm install and upgrade for KinD example demo

### DIFF
--- a/examples/kubernetes-in-docker/0_export_env_vars.sh
+++ b/examples/kubernetes-in-docker/0_export_env_vars.sh
@@ -19,6 +19,7 @@ export AUTHENTICATOR_ID="${AUTHENTICATOR_ID:-my-authenticator-id}"
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
 
 # KinD specific specific setting for demo scripts
+export CONJUR_LOADBALANCER_SVCS="${CONJUR_LOADBALANCER_SVCS:-false}"
 export TEST_APP_LOADBALANCER_SVCS="${TEST_APP_LOADBALANCER_SVCS:-false}"
 
 # You can choose to have the scripts create a local, insecure Docker registry

--- a/examples/kubernetes-in-docker/1_create_kind_cluster.sh
+++ b/examples/kubernetes-in-docker/1_create_kind_cluster.sh
@@ -22,7 +22,7 @@ if ! meets_min_version $kind_version $min_kind_version; then
 fi
 
 registry_container_is_running() {
-  "$(docker inspect -f '{{.State.Running}}' $DOCKER_LOCAL_REGISTRY_NAME 2>/dev/null || true)"
+  docker inspect -f '{{.State.Running}}' $DOCKER_LOCAL_REGISTRY_NAME 2>/dev/null
 }
  
 # Check if KinD cluster has already been created
@@ -46,6 +46,10 @@ elif [[ $USE_DOCKER_LOCAL_REGISTRY == "true" ]]; then
     
   # create registry container unless it already exists
   if ! registry_container_is_running; then
+    echo "Creating a registry container"
+    # Create a Docker network named 'kind' if not already created
+    docker network inspect kind >/dev/null 2>&1 || \
+      docker network create kind
     docker run \
       -d --restart=always -p "${reg_port}:${reg_port}" --name "${reg_name}" --net=kind \
       registry:2

--- a/examples/kubernetes-in-docker/2_helm_install_or_upgrade_conjur.sh
+++ b/examples/kubernetes-in-docker/2_helm_install_or_upgrade_conjur.sh
@@ -28,17 +28,22 @@ fi
 # Check if the Conjur cluster release has already been installed. If so, run
 # Helm upgrade. Otherwise, do a Helm install of the Conjur cluster.
 if [ "$(helm list -q -n $CONJUR_NAMESPACE | grep "^$HELM_RELEASE$")" = "$HELM_RELEASE" ]; then
+  echo "Helm upgrading existing Conjur cluster. Waiting for upgrade to complete."
   helm upgrade \
       -n "$CONJUR_NAMESPACE" \
       --set account.name="$CONJUR_ACCOUNT" \
       --set account.create="true" \
       --set authenticators="authn\,authn-k8s/$AUTHENTICATOR_ID" \
       --set logLevel="$CONJUR_LOG_LEVEL" \
+      --set service.external.enabled="$CONJUR_LOADBALANCER_SVCS" \
       --reuse-values \
+      --wait \
+      --timeout 300s \
       "$HELM_RELEASE" \
       "../../conjur-oss"
 else
   # Helm install a Conjur cluster and create a Conjur account
+  echo "Helm installing a Conjur cluster. Waiting for install to complete."
   data_key="$(docker run --rm cyberark/conjur data-key generate)"
   helm install \
       -n "$CONJUR_NAMESPACE" \
@@ -47,6 +52,9 @@ else
       --set account.create="true" \
       --set authenticators="authn\,authn-k8s/$AUTHENTICATOR_ID" \
       --set logLevel="$CONJUR_LOG_LEVEL" \
+      --set service.external.enabled="$CONJUR_LOADBALANCER_SVCS" \
+      --wait \
+      --timeout 300s \
       "$HELM_RELEASE" \
       "../../conjur-oss"
 fi

--- a/examples/kubernetes-in-docker/4_ensure_authn_k8s_enabled.sh
+++ b/examples/kubernetes-in-docker/4_ensure_authn_k8s_enabled.sh
@@ -16,14 +16,12 @@ if grep -q "$authenticators" <<< "$AUTHENTICATOR_ID"; then
        --reuse-values \
        --set authenticators="authn\,authn-k8s/$AUTHENTICATOR_ID" \
        --set logLevel="$CONJUR_LOG_LEVEL" \
+       --wait \
+       --timeout 300s \
        "$HELM_RELEASE" \
        ../../conjur-oss
 
-  # Pause to let Helm begin to terminate existing pods as a result
-  # of Helm upgrade
-  sleep 5
-
-  # Wait for Conjur master pod to have both containers ready
+  # Wait for Conjur pods become ready
   wait_for_conjur_ready
 
 else

--- a/examples/kubernetes-in-docker/start
+++ b/examples/kubernetes-in-docker/start
@@ -56,10 +56,8 @@ if [ $HELM_INSTALL_CONJUR = "true" ]; then
   announce "Helm installing/upgrading Conjur OSS cluster"
   ./2_helm_install_or_upgrade_conjur.sh
 
-  # Pause to let Helm begin to terminate existing pods for the
-  # Helm upgrade case
-  sleep 5
-
+  # Wait for Conjur pods to become ready (just in case there are old
+  # Conjur pods getting terminated as part of Helm upgrade)
   announce "Waiting for Conjur to become ready"
   wait_for_conjur_ready
 fi


### PR DESCRIPTION
### What does this PR do?

This change adds a few things for the KinD example demo:

- Adds waits for helm install and upgrade operations
- Adds option to disable loadbalancers for Conjur
  (defaults to disable, this is needed for Helm install/upgrade
  waits to avoid waiting for services that are "Pending" forever
  waiting for external IPs that will never get assigned)
- Creates a Docker network named 'kind' if necessary before
  creating a Docker registry container. This is needed in order
  to support someone running these scripts from scratch
  (i.e. the 'kind' network hasn't been created by KinD yet).
- Fixes problem with the way we were checking for a running
  Docker registry container.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation