### PR TITLE
Only allow strings for image tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Image `tag` values must now include surrouding quotes when they are
+  set in a values.yaml file. Arbitrary tag strings are allowed now
+  (e.g. "latest" is allowable).
+
 ## [v2.0.1] - 2020-10-30
 
 ### Added

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -78,9 +78,8 @@
           "type": "string"
         },
         "tag": {
-          "type": [ "string", "number" ],
-          "pattern": "(^\\d+(\\.\\d+){0,2})$"
-        }
+          "type": "string"
+       }
       }
     },
     "nginx": {
@@ -94,8 +93,7 @@
               "type": "string"
             },
             "tag": {
-              "type": [ "string", "number" ],
-              "pattern": "(^\\d+(\\.\\d+){0,2})$"
+              "type": "string"
             }
           }
         }
@@ -115,8 +113,7 @@
               "type": "string"
             },
             "tag": {
-              "type": [ "string", "number" ],
-              "pattern": "(^\\d+(\\.\\d+){0,2})$"
+              "type": "string"
             }
           }
         },

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -64,7 +64,7 @@ deployment:
 image:
   pullPolicy: Always
   repository: cyberark/conjur  # https://hub.docker.com/r/cyberark/conjur/
-  tag: 1.5
+  tag: '1.5'
 
 nginx:
   image:


### PR DESCRIPTION
### What does this PR do?

The following changes are made to the schema restrictions for image
tags in the Conjur Helm chart:

- Numeric values are no longer allowed for image tags.
  In other words, image tag values must now be surrounded in quotes.
  This restriction is being added to avoid the pitfall of allowing
  someone to enter a tag in the form of a [major-number].[minor-number]
  numeric value, where the minor number is a multiple of 10 (e.g. `1.10`).
  In this case the minor number gets interpreted as a decimal fraction, leading to
  trailing zeros to get truncated (i.e. gets mistranslated to `1.1`).
- Arbitrary strings are now allowed for image tags. For example,
  the image tag can be set to something like "latest".

This change does not effect the default values that are defined for
the various tag values.

### What ticket does this PR close?
Resolves #106

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation