### PR TITLE
Upgrades Conjur version to 1.10 and postgres version to 10.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
+- Default Conjur version is upgraded from 1.5 to 1.10. Default Postgres
+  version is upgraded from 10.12 to 10.14.
 - Image `tag` values must now include surrouding quotes when they are
   set in a values.yaml file. Arbitrary tag strings are allowed now
   (e.g. "latest" is allowable).

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -145,7 +145,7 @@ $  CONJUR_NAMESPACE=my-conjur-namespace
 $  kubectl create namespace "$CONJUR_NAMESPACE"
 $  DATA_KEY="$(docker run --rm cyberark/conjur data-key generate)"
 $  HELM_ARGS="--set dataKey=$DATA_KEY \
-              --set image.tag=1.5.1 \
+              --set image.tag=1.11.0 \
               --set image.pullPolicy=IfNotPresent \
               --set ssl.hostname=custom.domainname.com
 $  helm install \
@@ -170,7 +170,7 @@ authenticators: "authn-k8s/minikube,authn"
 dataKey: $DATA_KEY
 
 image:
-  tag: "1.5.1"
+  tag: "1.11.0"
   pullPolicy: IfNotPresent
 
 ssl:
@@ -340,7 +340,7 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`dataKey`|Conjur data key, 32 byte base-64 encoded string for data encryption.|`""`|
 |`deployment.annotations`|Annotations for Conjur deployment|`{}`|
 |`image.repository`|Conjur Docker image repository|`"cyberark/conjur"`|
-|`image.tag`|Conjur Docker image tag|`"1.5"`|
+|`image.tag`|Conjur Docker image tag|`"1.10"`|
 |`image.pullPolicy`|Pull policy for Conjur Docker image|`"Always"`|
 |`logLevel`|Conjur log level. Set to 'debug' to enable detailed debug logs in the Conjur container |`"info"`|
 |`nginx.image.repository`|NGINX Docker image repository|`"nginx"`|
@@ -348,7 +348,7 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`nginx.image.pullPolicy`|Pull policy for NGINX Docker image|`"IfNotPresent"`|
 |`postgres.image.pullPolicy`|Pull policy for postgres Docker image|`"IfNotPresent"`|
 |`postgres.image.repository`|postgres Docker image repository|`"postgres"`|
-|`postgres.image.tag`|postgres Docker image tag|`"10.12"`|
+|`postgres.image.tag`|postgres Docker image tag|`"10.14"`|
 |`postgres.persistentVolume.create`|Create a peristent volume to back the PostgreSQL data|`true`|
 |`postgres.persistentVolume.size`|Size of persistent volume to be created for PostgreSQL|`"8Gi"`|
 |`postgres.persistentVolume.storageClass`|Storage class to be used for PostgreSQL persistent volume claim|`nil`|

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -64,7 +64,7 @@ deployment:
 image:
   pullPolicy: Always
   repository: cyberark/conjur  # https://hub.docker.com/r/cyberark/conjur/
-  tag: '1.5'
+  tag: '1.10'
 
 nginx:
   image:
@@ -80,7 +80,7 @@ postgres:
   image:
     pullPolicy: Always
     repository: postgres       # https://hub.docker.com/_/postgres/
-    tag: '10.12'
+    tag: '10.14'
   persistentVolume:
     create: true
     size: 8Gi


### PR DESCRIPTION
Default versions of Conjur and Postgres are upgraded to maintain parity
with Conjur DAP:

- Upgrade default Conjur version from 1.5 to 1.10
- Upgrade default Postgres version from 1.12 to 10.14

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #108 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation