### PR TITLE
Cleans up test deployments/pods at end of KinD demo

### DIFF
--- a/examples/kubernetes-in-docker/5_deploy_demo_apps.sh
+++ b/examples/kubernetes-in-docker/5_deploy_demo_apps.sh
@@ -19,3 +19,15 @@ export CONJUR_NAMESPACE_NAME="$CONJUR_NAMESPACE"
 announce "Running the Kubernetes Conjur Demo scripts"
 cd "$conjur_demo_scripts_path"
 ./start
+
+announce "Cleaning up test/validation deployments and pods"
+# The 'test-app-with-host-outside-apps-branch-summon-init' deployment
+# is used to test that authentication works with the Conjur host defined
+# anywhere in the policy branch. It can be deleted now.
+kubectl delete deployment -n "$TEST_APP_NAMESPACE_NAME" \
+        test-app-with-host-outside-apps-branch-summon-init
+if [[ "$TEST_APP_LOADBALANCER_SVCS" == "false" ]]; then
+    kubectl delete pod -n "$TEST_APP_NAMESPACE_NAME" test-curl
+fi
+
+announce "Deployment of Conjur and demo applications is complete!"


### PR DESCRIPTION
### What does this PR do?
The changes include:
(1)  Clean up deployments and pods that are used for testing and
     validation of the Conjur/application setup, and can be deleted
     for the purposes of a demo:
     - `test-app-with-host-outside-apps-branch-summon-init` deployment.
       This deployment is used in the kubernetes-conjur-demo scripts to
       test that authentication works with the Conjur host defined anywhere
       in the policy branch.
     - `test-curl` pod, which is used to test application services from
       inside the Kubernetes cluster when there are no external IPs
       available.
(2) Updates the instructions in the demo README.md that show
    how to set up an alias to use the Conjur CLI pod. This makes the
    instructions more general.

### What ticket does this PR close?
Resolves #110

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation