### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
-- Default Conjur version is upgraded from 1.5 to 1.10. Default Postgres
+- Default Conjur version is upgraded from 1.5 to 1.11. Default Postgres
   version is upgraded from 10.12 to 10.14.
+  [cyberark/conjur-oss-helm-chart#112](https://github.com/cyberark/conjur-oss-helm-chart/issues/112),
+  [cyberark/conjur-oss-helm-chart#108](https://github.com/cyberark/conjur-oss-helm-chart/issues/108)
 - Image `tag` values must now include surrouding quotes when they are
   set in a values.yaml file. Arbitrary tag strings are allowed now
   (e.g. "latest" is allowable).
+  [cyberark/conjur-oss-helm-chart#106](https://github.com/cyberark/conjur-oss-helm-chart/issues/106)
 
 ## [v2.0.1] - 2020-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [v2.0.2] - 2020-12-02
+
 ### Changed
 - Default Conjur version is upgraded from 1.5 to 1.11. Default Postgres
   version is upgraded from 10.12 to 10.14.
@@ -116,7 +118,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - First version of chart available.
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.3.8...v2.0.0
 [1.3.8]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.3.7...v1.3.8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,17 @@ any additional information for contributing code to this project.
 
 ## Releasing
 
+### Upgrading Conjur version
+
+To upgrade the default Conjur version used by this chart, you will need to
+update the following files:
+- Update the [README](./conjur-oss/README.md) to change the default value for
+  `image.tag` in the [Configuration table](./conjur-oss/README.md#configuration)
+- Update the `tag` value for the `cyberark/conjur` image in
+  [conjur-oss/values.yaml](./conjur-oss/values.yaml)
+
+### Creating a new release
+
 To release a new version of this chart:
 - Make the appropriate changes
 - Update the version number in [`conjur-oss/Chart.yaml`](conjur-oss/Chart.yaml)

--- a/conjur-oss/Chart.yaml
+++ b/conjur-oss/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: conjur-oss
 home: https://www.conjur.org
-version: 2.0.1
+version: 2.0.2
 description: A Helm chart for CyberArk Conjur
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
 keywords:

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -340,7 +340,7 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`dataKey`|Conjur data key, 32 byte base-64 encoded string for data encryption.|`""`|
 |`deployment.annotations`|Annotations for Conjur deployment|`{}`|
 |`image.repository`|Conjur Docker image repository|`"cyberark/conjur"`|
-|`image.tag`|Conjur Docker image tag|`"1.10"`|
+|`image.tag`|Conjur Docker image tag|`"1.11.1"`|
 |`image.pullPolicy`|Pull policy for Conjur Docker image|`"Always"`|
 |`logLevel`|Conjur log level. Set to 'debug' to enable detailed debug logs in the Conjur container |`"info"`|
 |`nginx.image.repository`|NGINX Docker image repository|`"nginx"`|

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -64,7 +64,7 @@ deployment:
 image:
   pullPolicy: Always
   repository: cyberark/conjur  # https://hub.docker.com/r/cyberark/conjur/
-  tag: '1.10'
+  tag: '1.11.1'
 
 nginx:
   image:


### PR DESCRIPTION
### What does this PR do?
- Bumps the chart version to 2.0.2
- Bumps the Conjur version to 1.11.1
- Adds instructions to CONTRIBUTING for bumping the Conjur version

### What ticket does this PR close?
Resolves #112 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation