### PR TITLE
Fixes Conjur pod restarts with auto account creation enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The Conjur OSS helm chart has Community support for deploying Conjur OSS to OpenShift 4.x
   [cyberark/conjur-oss-helm-chart#60](https://github.com/cyberark/conjur-oss-helm-chart/issues/60)
 
+### Fixed
+- Eliminates indefinite Conjur pod crashes that would occur if a Conjur
+  cluster is Helm installed with the automatic Conjur account creation feature
+  enabled (e.g. with `--set account.create=true`), and then the Conjur pod
+  gets restarted for any reason before a Helm upgrade has been performed.
+  [cyberark/conjur-oss-helm-chart#119](https://github.com/cyberark/conjur-oss-helm-chart/issues/119)
+
 ## [v2.0.2] - 2020-12-02
 
 ### Changed

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -109,14 +109,18 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- if .Values.account.create }}
-{{- if .Release.IsUpgrade }}
-        # For Helm upgrade, we want to make server startup idempotent, i.e.
-        # tolerant of the chart setting 'account.create=true' being reused.
+        # If the configured account has already been created, then start the
+        # server without account creation. Otherwise, start the server with
+        # account creation.
         command: ["bash"]
-        args: ["-c", "conjurctl server --account={{ .Values.account.name }} || conjurctl server"]
-{{ else }}
-        args: ["server", "--account={{ .Values.account.name }}"]
-{{- end }}
+        args:
+        - -c
+        - |
+           if conjurctl role retrieve-key {{ .Values.account.name }}:user:admin >/dev/null 2>&1; then
+             conjurctl server;
+           else
+             conjurctl server --account={{ .Values.account.name }} | grep -v 'API key for admin:';
+           fi
 {{ else }}
         args: ["server"]
 {{- end }}

--- a/conjur-oss/templates/tests/test-simple-install.yaml
+++ b/conjur-oss/templates/tests/test-simple-install.yaml
@@ -32,7 +32,7 @@ spec:
     {{- if not .Values.openshift.enabled }}
     image: "{{ .Values.image.kubernetes.repository }}:{{ .Values.image.kubernetes.tag }}"
     {{- else }}
-    image: "{{ .Values.image.openshift.repository }}:{{ .Values.openshift.kubernetes.tag }}"
+    image: "{{ .Values.image.openshift.repository }}:{{ .Values.image.openshift.tag }}"
     {{- end }}
     workingDir: "/tools/bats"
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]


### PR DESCRIPTION
### What does this PR do?

This change eliminates continual, never-ending Conjur pod crashes that
occur if a Conjur cluster is Helm installed with the automatic Conjur account
creation feature enabled (e.g. with `--set account.create=true`), and then
the Conjur pod gets restarted for any reason before a Helm upgrade has been
performed.

The root cause of this problem is that when automatic Conjur account creation
is enabled, the startup command for the Conjur cluster was set to:

```
   conjurctl server --account=<conjur-server-account>
```

This command will then be used both for initial deployment and for
pod restarts. The problem with this startup command  is that for pod
restarts, the Conjur account has already been created and saved in
persistent database memory by the initial Conjur pod instance. The startup
command therefore fails in the new Conjur pod instance with the following
error:

```
Account '<conjur-account>' already exists
error: exit
```

The fix is to change the Conjur startup command in the Kubernetes manifests,
so that the sequence is:

- Try to start Conjur with account creation. If that works, we're done.
- If that fails, the failure *might* be due to the account already being created.
   To determine if that's the case, try to look up that account using
   `conjurctl role retrieve-key ...`.
   (NOTE: We can't run the `conjurctl role retrieve-key ...` command to check
    whether the account exists unless/until we've already tried to start Conjur
    with `conjurctl server ...`. Running `conjurctl server...` apparently sets up
    some run-time objects that `conjurctl role retrieve-key ...` depends upon.)
- If the Conjur account already exists, then start the Conjur server **without** 
    account creation.

### What ticket does this PR close?
Resolves #119

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation