### PR TITLE
Fixes Jenkins master branch 'InvalidImageName' failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           " | kubectl create -f -
 
           # Initialise
-          helm init --service-account tiller --wait
+          helm init --stable-repo-url https://charts.helm.sh/stable --service-account tiller --wait
 
       - name: Run integration tests
         run: ./test-minimal.sh

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -361,8 +361,10 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`database.ssl.key`|PostgreSQL TLS private key, base64 encoded.|`""`|
 |`dataKey`|Conjur data key, 32 byte base-64 encoded string for data encryption.|`""`|
 |`deployment.annotations`|Annotations for Conjur deployment|`{}`|
-|`image.repository`|Conjur Docker image repository|`"cyberark/conjur"`|
-|`image.tag`|Conjur Docker image tag|`"1.11.1"`|
+|`image.kubernetes.repository`|Conjur Docker image repository for Kubernetes platforms|`"cyberark/conjur"`|
+|`image.kubernetes.tag`|Conjur Docker image tag for Kubernetes platforms|`"1.11.1"`|
+|`image.openshift.repository`|Conjur Docker image repository for OpenShift platform|`"registry.connect.redhat.com/cyberark/conjur"`|
+|`image.openshift.tag`|Conjur Docker image tag for OpenShift platform|`"latest"`|
 |`image.pullPolicy`|Pull policy for Conjur Docker image|`"Always"`|
 |`logLevel`|Conjur log level. Set to 'debug' to enable detailed debug logs in the Conjur container |`"info"`|
 |`nginx.image.repository`|NGINX Docker image repository|`"nginx"`|

--- a/conjur-oss/templates/tests/test-simple-install.yaml
+++ b/conjur-oss/templates/tests/test-simple-install.yaml
@@ -29,7 +29,11 @@ spec:
       name: tools
   containers:
   - name: {{ .Release.Name }}-test
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    {{- if not .Values.openshift.enabled }}
+    image: "{{ .Values.image.kubernetes.repository }}:{{ .Values.image.kubernetes.tag }}"
+    {{- else }}
+    image: "{{ .Values.image.openshift.repository }}:{{ .Values.openshift.kubernetes.tag }}"
+    {{- end }}
     workingDir: "/tools/bats"
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
     env:


### PR DESCRIPTION
### What does this PR do?
This change fixes master branch build failures. Tests are failing
for both KinD GitHub Actions and the tests on GCP.

One issue is that the Helm template for the Helm test container
(`conjur-oss/templates/test/test-simple-install.yaml`) was not
updated with the new values schema for the Conjur image that
was introduced with the addition of OCP support to the Helm chart.
For example, the template should use `.Values.image.kubernetes.repository` or
`.Values.image.openshift.repository` instead of `.Values.image.repository`.

A second issue is that Helm V2 has a default stable repository of
`https://kubernetes-charts.storage.googleapis.com` which no longer resolves.
(See  https://stackoverflow.com/questions/61954440/how-to-resolve-https-kubernetes-charts-storage-googleapis-com-is-not-a-valid).

This change also updates the Configuration table in the Chart's
README.md to reflect the new schema for the Conjur image.

### What ticket does this PR close?
Resolves #122

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation