### PR TITLE
Shorten test-conjur-ssl-ca-cert-volume name

### DIFF
--- a/conjur-oss/templates/tests/test-simple-install.yaml
+++ b/conjur-oss/templates/tests/test-simple-install.yaml
@@ -42,13 +42,13 @@ spec:
     - mountPath: /tools
       name: tools
     - mountPath: /cacert
-      name: {{ .Release.Name }}-test-conjur-ssl-ca-cert-volume
+      name: {{ .Release.Name }}-test-ssl-ca-cert-volume
       readOnly: true
   volumes:
   - name: tests
     configMap:
       name: {{ template "conjur-oss.fullname" . }}-tests
-  - name: {{ .Release.Name }}-test-conjur-ssl-ca-cert-volume
+  - name: {{ .Release.Name }}-test-ssl-ca-cert-volume
     secret:
       secretName: {{ .Release.Name }}-conjur-ssl-ca-cert
       # Permission == 0400. JSON spec doesn’t support octal notation.


### PR DESCRIPTION
### What does this PR do?
There are implementations that adding Release.name to "test-conjur-ssl-ca-cert-volume" reaching the limit of 64 chars
removing `conjur` from naming will assist in meeting that limit

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation