### PR TITLE
Removes OCP specific image repository and tag values

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -111,7 +111,10 @@ $  helm install \
 
 ### Installation on OCP
 
-To install Conjur on OCP using the `openshift.enabled=true` value:
+To install Conjur on OCP, use the `openshift.enabled=true` value, and
+use images for Conjur, NGINX, and Postgres that are appropriate for an
+OpenShift platform. The following Helm install example includes the default
+values for Conjur, NGINX, Postgres images for deploying on OpenShift:
 
 ```sh-session
 $  CONJUR_NAMESPACE=<conjur-namespace>
@@ -120,6 +123,12 @@ $  DATA_KEY="$(docker run --rm cyberark/conjur data-key generate)"
 $  HELM_RELEASE=<helm-release>
 $  helm install \
    -n "$CONJUR_NAMESPACE" \
+   --set image.repository=registry.connect.redhat.com/cyberark/conjur \
+   --set image.tag=latest \
+   --set nginx.image.repository=registry.connect.redhat.com/cyberark/conjur-nginx \
+   --set nginx.image.tag=latest \
+   --set postgres.image.repository=registry.redhat.io/rhscl/postgresql-10-rhel7 \
+   --set postgres.image.tag=latest \
    --set openshift.enabled=true \
    --set dataKey="$DATA_KEY" \
    "$HELM_RELEASE" \
@@ -361,15 +370,14 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`database.ssl.key`|PostgreSQL TLS private key, base64 encoded.|`""`|
 |`dataKey`|Conjur data key, 32 byte base-64 encoded string for data encryption.|`""`|
 |`deployment.annotations`|Annotations for Conjur deployment|`{}`|
-|`image.kubernetes.repository`|Conjur Docker image repository for Kubernetes platforms|`"cyberark/conjur"`|
-|`image.kubernetes.tag`|Conjur Docker image tag for Kubernetes platforms|`"1.11.1"`|
-|`image.openshift.repository`|Conjur Docker image repository for OpenShift platform|`"registry.connect.redhat.com/cyberark/conjur"`|
-|`image.openshift.tag`|Conjur Docker image tag for OpenShift platform|`"latest"`|
+|`image.repository`|Conjur Docker image repository|`"cyberark/conjur"`|
+|`image.tag`|Conjur Docker image tag|`"1.11.1"`|
 |`image.pullPolicy`|Pull policy for Conjur Docker image|`"Always"`|
 |`logLevel`|Conjur log level. Set to 'debug' to enable detailed debug logs in the Conjur container |`"info"`|
 |`nginx.image.repository`|NGINX Docker image repository|`"nginx"`|
 |`nginx.image.tag`|NGINX Docker image tag|`"1.15"`|
 |`nginx.image.pullPolicy`|Pull policy for NGINX Docker image|`"IfNotPresent"`|
+|`openshift.enabled`|Indicates that Conjur is to be installed on an OpenShift platform|`false`|
 |`postgres.image.pullPolicy`|Pull policy for postgres Docker image|`"IfNotPresent"`|
 |`postgres.image.repository`|postgres Docker image repository|`"postgres"`|
 |`postgres.image.tag`|postgres Docker image tag|`"10.14"`|

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -57,11 +57,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Release.Name }}-nginx
-        {{- if not .Values.openshift.enabled }}
-        image: "{{ .Values.nginx.image.kubernetes.repository }}:{{ .Values.nginx.image.kubernetes.tag }}"
-        {{- else }}
-        image: "{{ .Values.nginx.image.openshift.repository }}:{{ .Values.nginx.image.openshift.tag }}"
-        {{- end }}
+        image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
         imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
         ports:
         - containerPort: 9443
@@ -102,11 +98,7 @@ spec:
         {{- end }}
 
       - name: {{ .Chart.Name }}
-        {{- if not .Values.openshift.enabled }}
-        image: "{{ .Values.image.kubernetes.repository }}:{{ .Values.image.kubernetes.tag }}"
-        {{- else }}
-        image: "{{ .Values.image.openshift.repository }}:{{ .Values.image.openshift.tag }}"
-        {{- end }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- if .Values.account.create }}
         # If the configured account has already been created, then start the

--- a/conjur-oss/templates/postgres-ocp.yaml
+++ b/conjur-oss/templates/postgres-ocp.yaml
@@ -44,7 +44,7 @@ spec:
       labels: *AppPostgresLabels
     spec:
       containers:
-      - image: "{{ .Values.postgres.image.openshift.repository }}:{{ .Values.postgres.image.openshift.tag }}"
+      - image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
         imagePullPolicy: IfNotPresent
         name: postgresql
         env:

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -47,7 +47,7 @@ spec:
       securityContext:
         fsGroup: 999
       containers:
-      - image: "{{ .Values.postgres.image.kubernetes.repository }}:{{ .Values.postgres.image.kubernetes.tag }}"
+      - image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
         imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
         name: postgres
         args: ["-c", "ssl=on", "-c", "ssl_cert_file=/etc/certs/tls.crt", "-c", "ssl_key_file=/etc/certs/tls.key"]

--- a/conjur-oss/templates/tests/test-simple-install.yaml
+++ b/conjur-oss/templates/tests/test-simple-install.yaml
@@ -29,11 +29,7 @@ spec:
       name: tools
   containers:
   - name: {{ .Release.Name }}-test
-    {{- if not .Values.openshift.enabled }}
-    image: "{{ .Values.image.kubernetes.repository }}:{{ .Values.image.kubernetes.tag }}"
-    {{- else }}
-    image: "{{ .Values.image.openshift.repository }}:{{ .Values.image.openshift.tag }}"
-    {{- end }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
     workingDir: "/tools/bats"
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
     env:

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -71,25 +71,11 @@
     },
     "image": {
       "properties": {
-        "kubernetes": {
-          "properties": {
-            "repository": {
-              "type": "string"
-            },
-            "tag": {
-              "type": "string"
-            }
-          }
+        "repository": {
+          "type": "string"
         },
-        "openshift": {
-          "properties": {
-            "repository": {
-              "type": "string"
-            },
-            "tag": {
-              "type": "string"
-            }
-          }
+        "tag": {
+          "type": "string"
         },
         "pullPolicy": {
           "type": "string"
@@ -100,31 +86,19 @@
       "properties": {
         "image": {
           "properties": {
-            "kubernetes": {
-              "properties": {
-                "repository": {
-                  "type": "string"
-                },
-                "tag": {
-                  "type": "string"
-                }
-              }
-            },
-            "openshift": {
-              "properties": {
-                "repository": {
-                  "type": "string"
-                },
-                "tag": {
-                  "type": "string"
-                }
-              }
-            },
-            "pullPolicy": {
+            "repository": {
               "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+              "pullPolicy": {
+                "type": "string"
             }
           }
-        },
+        }
+      }
+    },
     "nodeSelector": {
       "type": "object"
     },
@@ -132,25 +106,11 @@
       "properties": {
         "image": {
           "properties": {
-            "kubernetes": {
-              "properties": {
-                "repository": {
-                  "type": "string"
-                },
-                "tag": {
-                  "type": "string"
-                }
-              }
+            "repository": {
+              "type": "string"
             },
-            "openshift": {
-              "properties": {
-                "repository": {
-                  "type": "string"
-                },
-                "tag": {
-                  "type": "string"
-                }
-              }
+            "tag": {
+              "type": "string"
             },
             "pullPolicy": {
               "type": "string"

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -62,22 +62,24 @@ deployment:
   annotations: {}
 
 image:
-  kubernetes:
-    repository: cyberark/conjur  # https://hub.docker.com/r/cyberark/conjur/
-    tag: '1.11.1'
-  openshift:
-    repository: registry.connect.redhat.com/cyberark/conjur
-    tag: latest
+  # NOTE: For OpenShift deployments, the default values to use for the
+  # Conjur image are as follows:
+  #
+  # repository: registry.connect.redhat.com/cyberark/conjur
+  # tag: latest
+  repository: cyberark/conjur  # https://hub.docker.com/r/cyberark/conjur/
+  tag: '1.11.1'
   pullPolicy: Always
 
 nginx:
   image:
-    kubernetes:
-      repository: nginx          # https://hub.docker.com/_/nginx/
-      tag: '1.15'
-    openshift:
-      repository: registry.connect.redhat.com/cyberark/conjur-nginx
-      tag: latest
+    # NOTE: For OpenShift deployments, the default values to use for the
+    # NGINX image are as follows:
+    #
+    # repository: registry.connect.redhat.com/cyberark/conjur-nginx
+    # tag: latest
+    repository: nginx          # https://hub.docker.com/_/nginx/
+    tag: '1.15'
     pullPolicy: Always
       
 # nodeSelector (node selection constraints) to apply to the Conjur pod. Refer to:
@@ -86,12 +88,13 @@ nodeSelector: {}
 
 postgres:
   image:
-    kubernetes:
-      repository: postgres       # https://hub.docker.com/_/postgres/
-      tag: '10.14'
-    openshift:
-      repository: registry.redhat.io/rhscl/postgresql-10-rhel7      # https://catalog.redhat.com/software/containers/rhscl/postgresql-10-rhel7/5aa63541ac3db95f196086f1?container-tabs=overview
-      tag: latest
+    # NOTE: For OpenShift deployments, the default values to use for the
+    # postgres image are as follows:
+    #
+    # repository: registry.redhat.io/rhscl/postgresql-10-rhel7
+    # tag: latest
+    repository: postgres       # https://hub.docker.com/_/postgres/
+    tag: '10.14'
     pullPolicy: Always
       
   persistentVolume:


### PR DESCRIPTION
### What does this PR do?

This change eliminates the OpenShift specific image repository and tag
values from the chart. This is being done to revert breaking changes
in chart values that added separate image repository/tag values
for Kubernetes vs OpenShift platforms. This change combines the
various Kubernetes / Openshift values into common values:

- Conjur repository
- Conjur tag
- Postgres repository
- Postgres tag
- Nginx repository
- Nginx tag

The defaults for these values will be the Kubernetes platform default
values. For deploying on OpenShift, the user will need to explicitly
set these to values that are appropriate for OpenShift.

The default values to use for OpenShift are documented in the chart's
README.md and in the `values.yaml` file.

### What ticket does this PR close?
Resolves #125

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation