### PR TITLE
Increment pg container version to 10.16 from 10.15.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- The default Postgres server version is incremented to 10.16 from 10.15. [Postgres 10.16](https://www.postgresql.org/docs/10/release-10-16.html)
+
 ## [v2.0.3] - 2020-12-30
 
 ### Added

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -380,7 +380,7 @@ The following table lists the configurable parameters of the Conjur OSS chart an
 |`openshift.enabled`|Indicates that Conjur is to be installed on an OpenShift platform|`false`|
 |`postgres.image.pullPolicy`|Pull policy for postgres Docker image|`"IfNotPresent"`|
 |`postgres.image.repository`|postgres Docker image repository|`"postgres"`|
-|`postgres.image.tag`|postgres Docker image tag|`"10.15"`|
+|`postgres.image.tag`|postgres Docker image tag|`"10.16"`|
 |`postgres.persistentVolume.create`|Create a peristent volume to back the PostgreSQL data|`true`|
 |`postgres.persistentVolume.size`|Size of persistent volume to be created for PostgreSQL|`"8Gi"`|
 |`postgres.persistentVolume.storageClass`|Storage class to be used for PostgreSQL persistent volume claim|`nil`|

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -94,7 +94,7 @@ postgres:
     # repository: registry.redhat.io/rhscl/postgresql-10-rhel7
     # tag: latest
     repository: postgres       # https://hub.docker.com/_/postgres/
-    tag: '10.15'
+    tag: '10.16'
     pullPolicy: Always
       
   persistentVolume:


### PR DESCRIPTION
### What does this PR do?
Increment pg container version to 10.16 from 10.15.

New release changelog: https://www.postgresql.org/docs/10/release-10-16.html

### What ticket does this PR close?
Resolves #120 ++ : N/A

### Checklists

#### Change log
- [x ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x ] The changes in this PR do not require tests

#### Documentation
- [ x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation