### PR TITLE
Run GitHub actions for pull requests and push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,17 @@
 name: CI
 
 on:
-  # Run this workflow on all push events
+  # Run this on pushes to master
   push:
+    branches:
+    - master
+
+  # Or when PR operations are done
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
 
 jobs:
   linter:


### PR DESCRIPTION
### What does this PR do?

Currently, GitHub actions testing isn't performed for pull requests
from a community contributor. This adds a trigger to run the
GH actions tests for `pull_request` events, to that tests are run
for PRs from everyone in the community.

### What ticket does this PR close?
Resolves #[]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation