### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # conjur-oss-helm-chart
 
-[Helm](https://github.com/helm/helm) chart for [Conjur OSS](https://www.conjur.org).
+[Helm](https://github.com/helm/helm) chart for [Conjur Open Source](https://www.conjur.org).
 
 [![GitHub release](https://img.shields.io/github/release/cyberark/conjur-oss-helm-chart.svg)](https://github.com/cyberark/conjur-oss-helm-chart/releases/latest)
 [![pipeline status](https://gitlab.com/cyberark/conjur-oss-helm-chart/badges/master/pipeline.svg)](https://gitlab.com/cyberark/conjur-oss-helm-chart/pipelines)
@@ -9,7 +9,7 @@
 
 ---
 
-## Using conjur-oss-helm-chart with Conjur OSS 
+## Using conjur-oss-helm-chart with Conjur Open Source 
 
 See [./conjur-oss](conjur-oss) for Chart files and instructions.
 

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -1,4 +1,4 @@
-# Conjur OSS Helm Chart
+# Conjur Open Source Helm Chart
 
 [CyberArk Conjur Open Source](https://www.conjur.org) is a powerful secrets management solution,
 tailored specifically to the unique infrastructure requirements of
@@ -24,8 +24,8 @@ Conjur Open Source is part of the CyberArk Privileged Access Security Solution w
   * [Configuring Conjur Accounts](#configuring-conjur-accounts)
   * [Installing Conjur with an External Postgres Database](#installing-conjur-with-an-external-postgres-database)
   * [Auto-Generated Configuration](#auto-generated-configuration)
-- [Upgrading, Modifying, or Migrating a Conjur OSS Helm Deployment](#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)
-  * [Modifying environment variables for an existing Conjur OSS Helm Deployment](#modifying-environment-variables-for-an-existing-conjur-oss-helm-deployment)
+- [Upgrading, Modifying, or Migrating a Conjur Open Source Helm Deployment](#upgrading-modifying-or-migrating-a-conjur-open-source-helm-deployment)
+  * [Modifying environment variables for an existing Conjur Open Source Helm Deployment](#modifying-environment-variables-for-an-existing-conjur-open-source-helm-deployment)
     + [Example: Changing Log Level](#example-changing-log-level)
 - [Configuration](#configuration)
   * [Deploying Without Persistent Volume Support (e.g. for MiniKube, KataCoda)](#deploying-without-persistent-volume-support-eg-for-minikube-katacoda)
@@ -278,7 +278,7 @@ database will be deployed along with Conjur.
 
 ### Auto-Generated Configuration
 
-By default, a `helm install` of the Conjur OSS helm chart will include
+By default, a `helm install` of the Conjur Open Source helm chart will include
 automatic generation of the following configuration:
 
 - Postgres database password (for integrated Postgres database only).
@@ -320,20 +320,20 @@ automatic generation of the following configuration:
       --set ssl.key=<your-ssl-key>
   ```
 
-## Upgrading, Modifying, or Migrating a Conjur OSS Helm Deployment
+## Upgrading, Modifying, or Migrating a Conjur Open Source Helm Deployment
 
 This Helm chart supports modifications or upgrades of a Conjur deployment via the
 [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/#helm) command. 
 This includes tasks such as rotating SSL certificates.
 
-For details on how to upgrade or modify an existing Conjur OSS Helm deployment,
-or migrate Conjur configuration from on Conjur OSS Helm deployment to a new,
-separate Conjur OSS Helm deployment, please see the
+For details on how to upgrade or modify an existing Conjur Open Source Helm deployment,
+or migrate Conjur configuration from on Conjur Open Source Helm deployment to a new,
+separate Conjur Open Source Helm deployment, please see the
 [UPGRADING.md](UPGRADING.md) markdown file.
 
-### Modifying environment variables for an existing Conjur OSS Helm Deployment
+### Modifying environment variables for an existing Conjur Open Source Helm Deployment
 
-After deploying the Conjur OSS using the helm chart, you may need to add or modify an 
+After deploying the Conjur Open Source using the helm chart, you may need to add or modify an 
 environment variable within the Conjur container. This task can be performed without needing 
 to tear down your existing deployment by using the `helm upgrade` command. 
 
@@ -356,7 +356,7 @@ $  helm upgrade \
 
 ## Configuration
 
-The following table lists the configurable parameters of the Conjur OSS chart and their default values.
+The following table lists the configurable parameters of the Conjur Open Source chart and their default values.
 
 |Parameter|Description|Default|
 |---------|-----------|-------|
@@ -489,13 +489,13 @@ The following restrictions apply to the PostgreSQL database password:
 
 If you are new to Conjur, you may be interested in learning more about how
 Conjur security policy can be configured and an application can
-be deployed that uses Conjur OSS to safely manage secrets data.
+be deployed that uses Conjur Open Source to safely manage secrets data.
 
 This repository contains a set of scripts that can:
 
 - Create a [Kubernetes-in-Docker](https://github.com/kubernetes-sigs/kind)
   (KinD) cluster on your local machine
-- Helm install a Conjur OSS cluster on that KinD cluster
+- Helm install a Conjur Open Source cluster on that KinD cluster
 - Enable the
   [Conjur Kubernetes Authenticator](https://docs.conjur.org/Latest/en/Content/Operations/Services/k8s_auth.htm)
   (authn-k8s) (as a security admin)

--- a/conjur-oss/UPGRADING.md
+++ b/conjur-oss/UPGRADING.md
@@ -1,58 +1,58 @@
-# Upgrading, Modifying, or Migrating a Conjur OSS Helm Deployment
+# Upgrading, Modifying, or Migrating a Conjur Open Source Helm Deployment
 
 This guide describes how to upgrade, modify, or migrate data from a
-[CyberArk Conjur Open Source](https://www.conjur.org) (Conjur OSS)
+[CyberArk Conjur Open Source](https://www.conjur.org) (Conjur Open Source)
 installation that has been deployed using the
-[Conjur OSS Helm Chart](https://github.com/cyberark/conjur-oss-helm-chart/conjur-oss).
+[Conjur Open Source Helm Chart](https://github.com/cyberark/conjur-oss-helm-chart/conjur-oss).
 
 There are two main scenarios covered in this document:
-- Upgrading/Modifying an existing Conjur OSS Helm release
-- Migrating configuration from an existing Conjur OSS Helm release
-  to a new Conjur OSS Helm Release
+- Upgrading/Modifying an existing Conjur Open Source Helm release
+- Migrating configuration from an existing Conjur Open Source Helm release
+  to a new Conjur Open Source Helm Release
 
-For more details about installing Conjur OSS or contributing to Conjur OSS
+For more details about installing Conjur Open Source or contributing to Conjur Open Source
 Helm chart development, please refer to the
-[Conjur OSS Helm Chart repository](https://github.com/cyberark/conjur-oss-helm-chart/conjur-oss).
+[Conjur Open Source Helm Chart repository](https://github.com/cyberark/conjur-oss-helm-chart/conjur-oss).
 
-To see what Conjur OSS Helm chart configurations can be upgraded/updated,
+To see what Conjur Open Source Helm chart configurations can be upgraded/updated,
 please refer to the [Configuration](README.md#configuration) section of
-the Conjur OSS Helm chart [README.md](README.md) file.
+the Conjur Open Source Helm chart [README.md](README.md) file.
 
 ---
 
 ## Table of Contents
 
 - [Prerequisites and Guidelines](#prerequisites-and-guidelines)
-- [Upgrading/Modifying a Conjur OSS Helm Release](#upgradingmodifying-a-conjur-oss-helm-release)
+- [Upgrading/Modifying a Conjur Open Source Helm Release](#upgradingmodifying-a-conjur-open-source-helm-release)
   * [Running Helm Upgrade](#running-helm-upgrade)
     + [Example: Upgrading Conjur Version](#example-upgrading-conjur-version)
     + [Example: Upgrading NGINX Version](#example-upgrading-nginx-version)
   * [Rotating the SSL Certificate for an Integrated Postgres Database](#rotating-the-ssl-certificate-for-an-integrated-postgres-database)
   * [Rotating the Conjur SSL CA and Access Certificates](#rotating-the-conjur-ssl-ca-and-access-certificates)
   * [Updating the Database URL for an External Postgres Database](#updating-the-database-url-for-an-external-postgres-database)
-- [Migrating Conjur OSS Configuration to a New Conjur OSS Helm Release](#migrating-conjur-oss-configuration-to-a-new-conjur-oss-helm-release)
+- [Migrating Conjur Open Source Configuration to a New Conjur Open Source Helm Release](#migrating-conjur-oss-configuration-to-a-new-conjur-open-source-helm-release)
   * [Overview](#overview)
   * [Assumptions and Limitations](#assumptions-and-limitations)
-  * [Migrating Conjur OSS Configuration With Integrated Postgres Database](#migrating-conjur-oss-configuration-with-integrated-postgres-database)
+  * [Migrating Conjur Open Source Configuration With Integrated Postgres Database](#migrating-conjur-open-source-configuration-with-integrated-postgres-database)
     + [Step 1: Save Helm State and Kubernetes Secrets Data](#step-1-save-helm-state-and-kubernetes-secrets-data)
     + [Step 2: Save Postgres Database State](#step-2-save-postgres-database-state)
-    + [Step 3: Uninstall Original Conjur OSS Helm Release](#step-3-uninstall-original-conjur-oss-helm-release)
-    + [Step 4: Helm Install a New Conjur OSS Deployment](#step-4-helm-install-a-new-conjur-oss-deployment)
+    + [Step 3: Uninstall Original Conjur Open Source Helm Release](#step-3-uninstall-original-conjur-open-source-helm-release)
+    + [Step 4: Helm Install a New Conjur Open Source Deployment](#step-4-helm-install-a-new-conjur-open-source-deployment)
     + [Step 5: Restore the Postgres Database](#step-5-restore-the-postgres-database)
     + [Step 6: Redeploy helm chart with updated 'replicaCount'](#step-6-redeploy-helm-chart-with-updated-replicaCount)
-  * [Migrating Conjur OSS Configuration With External Postgres Database](#migrating-conjur-oss-configuration-with-external-postgres-database)
+  * [Migrating Conjur Open Source Configuration With External Postgres Database](#migrating-conjur-open-source-configuration-with-external-postgres-database)
     + [Step 1: Save Helm State and Kubernetes Secrets Data](#step-1-save-helm-state-and-kubernetes-secrets-data)
-    + [Step 2: Uninstall Original Conjur OSS Helm Release](#step-2-uninstall-original-conjur-oss-helm-release)
-    + [Step 3: Helm Install a New Conjur OSS Deployment](#step-3-helm-install-a-new-conjur-oss-deployment)
+    + [Step 2: Uninstall Original Conjur Open Source Helm Release](#step-2-uninstall-original-conjur-open-source-helm-release)
+    + [Step 3: Helm Install a New Conjur Open Source Deployment](#step-3-helm-install-a-new-conjur-open-source-deployment)
 
 ## Prerequisites and Guidelines
 
 Please refer to the
 [Prerequisites and Guidelines](README.md#prerequisites-and-guidelines)
-section of Conjur OSS helm chart [README.md](README.md) file for overall
-prerequisites and guidelines for using the Conjur OSS helm chart.
+section of Conjur Open Source helm chart [README.md](README.md) file for overall
+prerequisites and guidelines for using the Conjur Open Source helm chart.
 
-## Upgrading/Modifying a Conjur OSS Helm Release
+## Upgrading/Modifying a Conjur Open Source Helm Release
 
 This Helm chart supports modifications or upgrades of a Conjur deployment via
 `helm upgrade`. There are three upgrade scenarios to consider, depending on
@@ -167,7 +167,7 @@ $  helm upgrade \
 
 ### Rotating the SSL Certificate for an Integrated Postgres Database
 
-If a Helm deployment of Conjur OSS included the deployment of an integrated
+If a Helm deployment of Conjur Open Source included the deployment of an integrated
 Postgres database (i.e. the `database.url` chart value was not explicitly
 set for `helm install`), then `helm upgrade` operations will by default
 preserve the self-signed SSL certificate and key used to access the
@@ -181,7 +181,7 @@ manually updated (or "rotated") as follows:
 2. Delete the Kubernetes secret for the database SSL certificate. (Note:
    this is optional if the current database SSL certificate was set
    explicitly, but mandatory if the SSL certificate and key were
-   auto-generated by the Conjur OSS Helm chart):
+   auto-generated by the Conjur Open Source Helm chart):
 
 ```sh-session
 $  CONJUR_NAMESPACE="<conjur-namespace>"
@@ -279,41 +279,41 @@ $  helm upgrade \
        ./conjur-oss
 ```
 
-## Migrating Conjur OSS Configuration to a New Conjur OSS Helm Release
+## Migrating Conjur Open Source Configuration to a New Conjur Open Source Helm Release
 
 ### Overview
 
 In some cases, it may be desirable to migrate Conjur configuration from
-one Conjur OSS Helm release to a new, separate Helm release. For example,
-you may want to migrate your Conjur OSS deployment to a different
-Kubernetes provider, or you may want to move your Conjur OSS deployment
+one Conjur Open Source Helm release to a new, separate Helm release. For example,
+you may want to migrate your Conjur Open Source deployment to a different
+Kubernetes provider, or you may want to move your Conjur Open Source deployment
 to a more secure Kubernetes environment.
 
 This section provides the steps for extracting Conjur configuration from
-an existing Conjur OSS Helm deployment, and restoring that Conjur configuration
-on a new, separate Conjur OSS Helm deployment.
+an existing Conjur Open Source Helm deployment, and restoring that Conjur configuration
+on a new, separate Conjur Open Source Helm deployment.
 
-The backup operation from the original Conjur OSS deployment involves
-extracting Conjur OSS state from three sources:
+The backup operation from the original Conjur Open Source deployment involves
+extracting Conjur Open Source state from three sources:
 
 - Kubernetes secrets
 - Helm state
 - Postgres database state
 
-The restore operation to the new Conjur OSS deployment involves:
+The restore operation to the new Conjur Open Source deployment involves:
 
 - Running `helm init` to restore Helm state and Kubernetes secrets
 - Postgres restore of Conjur's database state
 
 ### Assumptions and Limitations
 
-- Currently, _the version of Conjur for the new Conjur OSS deployment
+- Currently, _the version of Conjur for the new Conjur Open Source deployment
   **MUST** be the same as the version of Conjur on the original Conjur
   OSS deployment_. (Support for migration to different versions of Conjur
   may be available in the future, but this will require schema translation
   logic that is TBD).
 - For deployments using an integrated Postgres database, _the **major**
-  version of Postgres in the new Conjur OSS deployment must be the
+  version of Postgres in the new Conjur Open Source deployment must be the
   same as the **major** version of Postgres in the original deployment_.
 - For simplicity, the instructions described here will include the
   recreation of only a critical **subset** of Helm state from the old Conjur
@@ -336,10 +336,10 @@ The restore operation to the new Conjur OSS deployment involves:
 - _**All instructions that follow assume that you are in the base of
   https://github.com/cyberark/conjur-oss-helm-chart repo**_
 
-### Migrating Conjur OSS Configuration With Integrated Postgres Database
+### Migrating Conjur Open Source Configuration With Integrated Postgres Database
 
-When a Conjur OSS Helm deployment includes an integrated (internal) Postgres
-database, the procedure for migrating Conjur OSS state to a new Conjur OSS
+When a Conjur Open Source Helm deployment includes an integrated (internal) Postgres
+database, the procedure for migrating Conjur Open Source state to a new Conjur Open Source
 Helm deployment is as follows:
 
 #### Step 1: Save Helm State and Kubernetes Secrets Data
@@ -368,13 +368,13 @@ $  data_key=$(kubectl get secret \
              base64 --decode)
 ```
 
-Next, check your Conjur OSS chart version:
+Next, check your Conjur Open Source chart version:
 
 ```sh-session
 $  helm show chart "$helm_chart_name"| awk '/^version:/{print $2}'
 ```
 
-If your Conjur OSS chart version is 2.0.0 or newer, then you will also need
+If your Conjur Open Source chart version is 2.0.0 or newer, then you will also need
 to store the database password:
 ```sh-session
 $  db_password=$(kubectl get secret \
@@ -404,9 +404,9 @@ $  kubectl exec -it \
 $  kubectl cp -n "$namespace" $postgres_old_pod:dbdump.tar dbdump.tar
 ```
 
-#### Step 3: Uninstall Original Conjur OSS Helm Release
+#### Step 3: Uninstall Original Conjur Open Source Helm Release
 
-Run `helm uninstall ...` to delete the original Conjur OSS Helm release
+Run `helm uninstall ...` to delete the original Conjur Open Source Helm release
 and delete any residual, "self-managed" Kubernetes secrets.
 
 **WARNING: This will remove your old certificates!**
@@ -416,7 +416,7 @@ $  helm uninstall -n "$namespace" $helm_chart_name
 $  kubectl delete secrets -n "$namespace" -l release="$helm_chart_name"
 ```
 
-#### Step 4: Helm Install a New Conjur OSS Deployment
+#### Step 4: Helm Install a New Conjur Open Source Deployment
 
 **WARNING: This will possibly change your external service IP!**
 
@@ -484,10 +484,10 @@ $  helm upgrade -n "$namespace" \
                 ./conjur-oss
 ```
 
-### Migrating Conjur OSS Configuration With External Postgres Database
+### Migrating Conjur Open Source Configuration With External Postgres Database
 
-When a Conjur OSS Helm deployment includes an external Postgres database,
-the procedure for migrating Conjur OSS state to a new Conjur OSS Helm
+When a Conjur Open Source Helm deployment includes an external Postgres database,
+the procedure for migrating Conjur Open Source state to a new Conjur Open Source Helm
 deployment is as follows:
 
 #### Step 1: Save Helm State and Kubernetes Secrets Data
@@ -519,9 +519,9 @@ $  db_url=$(kubectl get secret \
              base64 --decode)
 ```
 
-#### Step 2: Uninstall Original Conjur OSS Helm Release
+#### Step 2: Uninstall Original Conjur Open Source Helm Release
 
-Run `helm uninstall ...` to delete the original Conjur OSS Helm release
+Run `helm uninstall ...` to delete the original Conjur Open Source Helm release
 and delete any residual, "self-managed" Kubernetes secrets.
 
 **WARNING: This will remove your old certificates!**
@@ -531,7 +531,7 @@ $  helm uninstall -n "$namespace" $helm_chart_name
 $  kubectl delete secrets -n "$namespace" -l release="$helm_chart_name"
 ```
 
-#### Step 3: Helm Install a New Conjur OSS Deployment
+#### Step 3: Helm Install a New Conjur Open Source Deployment
 
 **WARNING: This will possibly change your external service IP!**
 

--- a/examples/kubernetes-in-docker/README.md
+++ b/examples/kubernetes-in-docker/README.md
@@ -1,4 +1,4 @@
-# All-in-One Demo: Deploy Kubernetes, Conjur OSS, and Applications that Retrieve Secrets Securely
+# All-in-One Demo: Deploy Kubernetes, Conjur Open Source, and Applications that Retrieve Secrets Securely
 
 ## Table of Contents
   * [What This Demonstration Does](#what-this-demonstration-does)
@@ -17,15 +17,15 @@
   * [Enabling Conjur Debug Logging](#enabling-conjur-debug-logging)
   * [Cleaning Up](#cleaning-up)
     + [Deleting the Kubernetes Conjur Demo Applications](#deleting-the-kubernetes-conjur-demo-applications)
-    + [Uninstalling Conjur OSS via Helm Delete](#uninstalling-conjur-oss-via-helm-delete)
+    + [Uninstalling Conjur Open Source via Helm Delete](#uninstalling-conjur-open-source-via-helm-delete)
     + [Deleting the KinD Cluster](#deleting-the-kind-cluster)
 
 ## What This Demonstration Does
 
 The scripts in this directory can be  used to run an "All-in-One"
-demonstration of how Conjur OSS  can be deployed along with a simple
+demonstration of how Conjur Open Source  can be deployed along with a simple
 [Pet Store](https://github.com/conjurdemos/pet-store-demo/) application
-that securely retrieves application-specific secrets from Conjur OSS.
+that securely retrieves application-specific secrets from Conjur Open Source.
 
 It is not necessary for you to have access to a Kubernetes cluster
 before running the scripts. The scripts conveniently create a local,
@@ -121,7 +121,7 @@ to access application-specific secrets from Conjur.
 ## Let's Run the Demo!
 
 1. Clone the
-   [Conjur OSS Helm Chart](https://github.com/cyberark/conjur-oss-helm-chart)
+   [Conjur Open Source Helm Chart](https://github.com/cyberark/conjur-oss-helm-chart)
    GitHub repository, if you haven't done so already.
 
    <details>
@@ -144,7 +144,7 @@ to access application-specific secrets from Conjur.
 
    That's all there is to it!
 
-   The scripts will create a KinD cluster, install Conjur OSS, load
+   The scripts will create a KinD cluster, install Conjur Open Source, load
    Conjur security policy, and deploy several instances of the `Pet Store`
    applications that use Conjur Kubernetes authentication.
 
@@ -164,7 +164,7 @@ If you followed the steps in the previous section, you should now have:
 
 - A local [Kubernetes-in-Docker (KinD)](https://github.com/kubernetes-sigs/kind)
   cluster that is running:
-  - A [Conjur OSS](https://docs.conjur.org/) server, with a peristent
+  - A [Conjur Open Source](https://docs.conjur.org/) server, with a peristent
     Postgresql backend database, that has the
     [Conjur Kubernetes Authenticator](https://docs.conjur.org/Latest/en/Content/Operations/Services/k8s_auth.htm)
     enabled
@@ -220,7 +220,7 @@ into four phases:
 - Platform Admin Tasks:
   - Create a local, containerized, Kubernetes cluster using
     [KinD](https://github.com/kubernetes-sigs/kind) Kubernetes cluster
-  - Helm install Conjur OSS
+  - Helm install Conjur Open Source
 - Security Admin Tasks:
   - Enable the
     [Conjur Kubernetes Authenticator](https://docs.conjur.org/Latest/en/Content/Operations/Services/k8s_auth.htm)
@@ -276,12 +276,12 @@ To view Kubernetes namespaces that have been created on the `kind` cluster:
 ### Exploring the `conjur-oss` Namespace
 
 This demonstration makes use of the
-[Conjur OSS Helm Chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss)
+[Conjur Open Source Helm Chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss)
 to install a Conjur cluster on the local KinD cluster.
 
-#### Conjur OSS Pods
+#### Conjur Open Source Pods
 
-To view the Conjur OSS cluster pods that are created by the Helm chart, run:
+To view the Conjur Open Source cluster pods that are created by the Helm chart, run:
 
 ```sh-session
     $ kubectl get pods -n conjur-oss -l release=conjur-oss
@@ -291,11 +291,11 @@ To view the Conjur OSS cluster pods that are created by the Helm chart, run:
     $
 ```
 
-The Helm install of Conjur OSS creates a Conjur OSS master pod and
+The Helm install of Conjur Open Source creates a Conjur Open Source master pod and
 a Postgresql pod to serve as a backend database to persistently store
-Conjur OSS policies and secrets.
+Conjur Open Source policies and secrets.
 
-The Conjur OSS master pod contains two containers:
+The Conjur Open Source master pod contains two containers:
 
 ```sh-session
     $ kubectl get pod -n conjur-oss -l app=conjur-oss -o jsonpath='{.items[*].spec.containers[*].name}'
@@ -303,29 +303,29 @@ The Conjur OSS master pod contains two containers:
     $
 ```
 
-The `conjur-oss` container provides the Conjur OSS server functionality,
+The `conjur-oss` container provides the Conjur Open Source server functionality,
 and the `conjur-oss-nginx` container terminates TLS for secure access to
-the Conjur OSS service.
+the Conjur Open Source service.
 
 #### Kubernetes Authentication ClusterRole
 
-The Conjur OSS Helm Chart includes the deployment of a
+The Conjur Open Source Helm Chart includes the deployment of a
 [Kubernetes ClusterRole](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)
 resource. A Kubernetes `ClusterRole` contains rules that
 enumerate a set of permissions to access various Kubernetes resources.
 
-In this case, the Conjur OSS authentication `ClusterRole` is used to enumerate
+In this case, the Conjur Open Source authentication `ClusterRole` is used to enumerate
 permissions that may be granted to the Conjur Kubernetes Authenticator
 *on a per-namespace basis* to allow the authenticator to authenticate
 applications based upon
 [Conjur application identity](https://docs.conjur.org/Latest/en/Content/Integrations/Kubernetes_AppIdentity.htm?TocPath=Integrations%7COpenShift%252C%20Kubernetes%252C%20and%20GKE%7C_____2).
 
 Note that the permissions that are included in this `ClusterRole`
-do not take effect until the `ClusterRole` is bound to the Conjur OSS
+do not take effect until the `ClusterRole` is bound to the Conjur Open Source
 service account via a namespace-scoped `RoleBinding`, as described in the
 [Demo Application RoleBinding](#demo-application-rolebinding) section below.
 
-To view the Conjur OSS authentication ClusterRole, run:
+To view the Conjur Open Source authentication ClusterRole, run:
 
 ```sh-session
     kubectl get clusterrole -n conjur-oss -l release=conjur-oss -o yaml
@@ -410,7 +410,7 @@ To view the Conjur OSS authentication ClusterRole, run:
 
 #### Viewing Enabled Conjur Authenticator Plugins
 
-Conjur OSS supports several industry-standard
+Conjur Open Source supports several industry-standard
 [authentication types](https://docs.conjur.org/Latest/en/Content/Operations/Services/authentication-types.htm#SupportedAuthenticators).
 Conjur can be configured to use on or a combination of authenticator types.
 
@@ -420,7 +420,7 @@ the Conjur
 applications based upon
 [Conjur Application Identity](https://docs.conjur.org/Latest/en/Content/Integrations/Kubernetes_AppIdentity.htm?TocPath=Integrations%7COpenShift%252C%20Kubernetes%252C%20and%20GKE%7C_____2).
 
-To view the authenticators that are enabled for Conjur OSS, run:
+To view the authenticators that are enabled for Conjur Open Source, run:
 
 ```sh-session
     $ authn_secret=$(kubectl get secret -n conjur-oss | grep authenticators | awk '{print $1}')
@@ -510,7 +510,7 @@ Or by using the `CONJUR_CMD` environment variable:
 
 The demo scripts render several YAML manifest files that define
 application-specific Conjur security policy. These YAML manifest files
-are loaded into the Conjur OSS server to configure which applications
+are loaded into the Conjur Open Source server to configure which applications
 are permitted to access secrets from Conjur.
 
 **After the demo scripts have been run**, it is possible to view the
@@ -754,9 +754,9 @@ Kubernetes resources can be cleaned up by deleting the `app-test` namespace:
 kubectl delete ns app-test
 ```
 
-### Uninstalling Conjur OSS via Helm Delete
+### Uninstalling Conjur Open Source via Helm Delete
 
-To remove the Conjur OSS deployment from your KinD cluster, run the following:
+To remove the Conjur Open Source deployment from your KinD cluster, run the following:
 
 ```sh-session
 CONJUR_NAMESPACE=conjur-oss


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
