### PR TITLE
Adds sample settings for validator IDs for KinD example

### DIFF
--- a/examples/kubernetes-in-docker/customize.env
+++ b/examples/kubernetes-in-docker/customize.env
@@ -45,3 +45,19 @@
 # Configuration for Conjur authn-k8s
 #export ANNOTATION_BASED_AUTHN="<true-or-false-defaults-to-true>"
 #export AUTHENTICATOR_ID="<authenticator-id-string-defaults-to-my-authenticator-id>"
+
+# Conjur policy options
+#
+# The 'kubernetes-conjur-demo' scripts that are used in this KinD example
+# generate and load Conjur policy that includes two, authenticate-only (i.e.
+# no access to Conjur secrets) "validator" host IDs. These host IDs can be
+# used to validate basic authentication with Conjur after configuring a
+# Kubenetes cluster or application namespace for Conjur authn-k8s support.
+# The following settings will be exported to the 'kubernetes-conjur-demo'
+# scripts to allow customization of these host IDs and the Namespaces from
+# which authentication validation will be performed.
+#
+#export VALIDATOR_ID="<conjur-policy-host-id-for-cluster-authn-validation-defaults-to-validator>"
+#export VALIDATOR_NAMESPACE_NAME="<namespace-used-for-authn-validation-defaults-to-CONJUR_NAMESPACE>"
+#export APP_VALIDATOR_ID="<conjur-policy-host-id-for-app-namespace-authn-validation-defaults-to-app-validator>"
+#export APP_VALIDATOR_ID="<namespace-used-for-app-namespace-authn-validation-defaults-to-TEST_APP_NAMESPACE_NAME>"


### PR DESCRIPTION
### What does this PR do?

The conjurdemos/kubernetes-conjur-demo scripts PR #140 adds support for 2
"validator" host IDs in Conjur policy that can be used to validate Conjur
authentication e.g. after a Kubernetes cluster or a Kubernetes Namespace
has been configured to support Conjur authn-k8s.

This change adds sample, customizable settings for configuring these authenticator validator
host IDs (and the Namespaces from which Conjur authentication will be validated)
for the Kubernetes-in-Docker (KinD) application deployment example.

### What ticket does this PR close?
Resolves #152

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation