### PR TITLE
Eliminates deprecation warnings for RBAC v1beta1 API versions

### DIFF
--- a/conjur-oss/templates/_helpers.tpl
+++ b/conjur-oss/templates/_helpers.tpl
@@ -76,12 +76,12 @@ Generate self-signed certificate for the backend database
 Return the most recent RBAC API available
 */}}
 {{- define "conjur-oss.rbac-api" -}}
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
-{{- printf "rbac.authorization.k8s.io/v1beta1" -}}
-{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
-{{- printf "rbac.authorization.k8s.io/v1alpha1" -}}
-{{- else }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 {{- printf "rbac.authorization.k8s.io/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+{{- printf "rbac.authorization.k8s.io/v1beta1" -}}
+{{- else }}
+{{- printf "rbac.authorization.k8s.io/v1alpha1" -}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### Desired Outcome

There should be no deprecation warnings regarding the use of RBAC API `v1beta1` version when the Conjur OSS Helm chart is installed or deleted.

### Implemented Changes

This change makes the `v1` RBAC API version the most preferred version to use if it is available on the Kubernetes API server, rather than `v1beta1`.

### Connected Issue/Story

Resolves #159 

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
- [x] Helm install of Conjur OSS Helm chart is performed, and there are no deprecation warnings re. RBAC API version v1beta1.
- [ ] All CI tests pass

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
