### PR TITLE
check for CONJUR_NAMESPACE_NAME

### DIFF
--- a/examples/kubernetes-in-docker/0_export_env_vars.sh
+++ b/examples/kubernetes-in-docker/0_export_env_vars.sh
@@ -1,8 +1,13 @@
-# KinD and Helm install options
+# KinD install options
 export CREATE_KIND_CLUSTER="${CREATE_KIND_CLUSTER:-true}"
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+
+# Helm install options
 export HELM_INSTALL_CONJUR="${HELM_INSTALL_CONJUR:-true}"
 export HELM_RELEASE="${HELM_RELEASE:-conjur-oss}"
+# The Conjur namespace name might be set with CONJUR_NAMESPACE_NAME in other projects
+# so look for both. Use CONJUR_NAMESPACE_NAME if both are set.
+export CONJUR_NAMESPACE="${CONJUR_NAMESPACE_NAME:-$CONJUR_NAMESPACE}"
 export CONJUR_NAMESPACE="${CONJUR_NAMESPACE:-conjur-oss}"
 export CONJUR_ACCOUNT="${CONJUR_ACCOUNT:-myConjurAccount}"
 export CONJUR_LOG_LEVEL="${CONJUR_LOG_LEVEL:-info}"

--- a/examples/openshift/0_export_env_vars.sh
+++ b/examples/openshift/0_export_env_vars.sh
@@ -1,8 +1,13 @@
-# KinD and Helm install options
-export CREATE_KIND_CLUSTER="${CREATE_KIND_CLUSTER:-true}"
+# KinD install options
+export CREATE_KIND_CLUSTER="${CREATE_KIND_CLUSTER:-false}"
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+
+# Helm install options
 export HELM_INSTALL_CONJUR="${HELM_INSTALL_CONJUR:-true}"
 export HELM_RELEASE="${HELM_RELEASE:-conjur-oss}"
+# The Conjur namespace name might be set with CONJUR_NAMESPACE_NAME in other projects
+# so look for both. Use CONJUR_NAMESPACE_NAME if both are set.
+export CONJUR_NAMESPACE="${CONJUR_NAMESPACE_NAME:-$CONJUR_NAMESPACE}"
 export CONJUR_NAMESPACE="${CONJUR_NAMESPACE:-conjur-oss}"
 export CONJUR_ACCOUNT="${CONJUR_ACCOUNT:-myConjurAccount}"
 export CONJUR_LOG_LEVEL="${CONJUR_LOG_LEVEL:-info}"


### PR DESCRIPTION
The environmental variable CONJUR_NAMESPACE was changed to CONJUR_NAMESPACE_NAME
in conjur-authn-k8s-client.

### Desired Outcome

If someone sets CONJUR_NAMESPACE_NAME, that value should be used.

### Implemented Changes

The there is an equivalent environmental variable to CONJUR_NAMESPACE in other projects called CONJUR_NAMESPACE_NAME. The purpose is to set the Conjur OSS namespace name in both cases. We need to check if either one exists when setting CONJUR_NAMESPACE. If both CONJUR_NAMESPACE and CONJUR_NAMESPACE_NAME are set we assume that CONJUR_NAMESPACE_NAME is the preferred name and will use that.

### Connected Issue/Story

Resolves #N/A

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
