### PR TITLE
Eliminates CONJUR_NAMESPACE undefined errors in KinD example

### DIFF
--- a/examples/common/utils.sh
+++ b/examples/common/utils.sh
@@ -32,7 +32,7 @@ get_master_pod_name() {
 }
 
 has_namespace() {
-  if kubectl get namespace  "$1" > /dev/null; then
+  if kubectl get namespace  "$1" &>/dev/null; then
     true
   else
     false

--- a/examples/kubernetes-in-docker/0_export_env_vars.sh
+++ b/examples/kubernetes-in-docker/0_export_env_vars.sh
@@ -5,10 +5,10 @@ export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 # Helm install options
 export HELM_INSTALL_CONJUR="${HELM_INSTALL_CONJUR:-true}"
 export HELM_RELEASE="${HELM_RELEASE:-conjur-oss}"
-# The Conjur namespace name might be set with CONJUR_NAMESPACE_NAME in other projects
-# so look for both. Use CONJUR_NAMESPACE_NAME if both are set.
-export CONJUR_NAMESPACE="${CONJUR_NAMESPACE_NAME:-$CONJUR_NAMESPACE}"
+# The Conjur namespace name might be set with CONJUR_NAMESPACE_NAME in other
+# projects so look for both. Use CONJUR_NAMESPACE_NAME if both are set.
 export CONJUR_NAMESPACE="${CONJUR_NAMESPACE:-conjur-oss}"
+export CONJUR_NAMESPACE="${CONJUR_NAMESPACE_NAME:-$CONJUR_NAMESPACE}"
 export CONJUR_ACCOUNT="${CONJUR_ACCOUNT:-myConjurAccount}"
 export CONJUR_LOG_LEVEL="${CONJUR_LOG_LEVEL:-info}"
 

--- a/examples/openshift/0_export_env_vars.sh
+++ b/examples/openshift/0_export_env_vars.sh
@@ -5,10 +5,10 @@ export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 # Helm install options
 export HELM_INSTALL_CONJUR="${HELM_INSTALL_CONJUR:-true}"
 export HELM_RELEASE="${HELM_RELEASE:-conjur-oss}"
-# The Conjur namespace name might be set with CONJUR_NAMESPACE_NAME in other projects
-# so look for both. Use CONJUR_NAMESPACE_NAME if both are set.
-export CONJUR_NAMESPACE="${CONJUR_NAMESPACE_NAME:-$CONJUR_NAMESPACE}"
+# The Conjur namespace name might be set with CONJUR_NAMESPACE_NAME in other
+# projects so look for both. Use CONJUR_NAMESPACE_NAME if both are set.
 export CONJUR_NAMESPACE="${CONJUR_NAMESPACE:-conjur-oss}"
+export CONJUR_NAMESPACE="${CONJUR_NAMESPACE_NAME:-$CONJUR_NAMESPACE}"
 export CONJUR_ACCOUNT="${CONJUR_ACCOUNT:-myConjurAccount}"
 export CONJUR_LOG_LEVEL="${CONJUR_LOG_LEVEL:-info}"
 


### PR DESCRIPTION
Currently, if you run the Kubernetes-in-Docker (KinD) example in 'examples/kubernetes-in-docker', the scripts generate an error for CONJUR_NAMESPACE being an undefined environment variable, and the scripts fail. This is easily fixed by reversing the order in which CONJUR_NAMESPACE and CONJUR_NAMESPACE_NAME environment variables are evaluated.

This also eliminates a minor, benign error message about a non-existent "conjur-oss" Namespace when the scripts check to see if this Namespace exists and it does not exist.

### Desired Outcome

- The KinD example scripts do not crash.
- The KinD example scripts do not emit a benign error about "conjur-oss" Namespace not existing the first time they are run. 

### Implemented Changes

- Order in which CONJUR_NAMESPACE and CONJUR_NAMESPACE_NAME are evaluated is reversed
- Error message when scripts check whether conjur-oss exists or not are redirected to /dev/null

### Connected Issue/Story

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
