### PR TITLE
Do not add unique id to service name

### DIFF
--- a/examples/common/2_helm_install_or_upgrade_conjur.sh
+++ b/examples/common/2_helm_install_or_upgrade_conjur.sh
@@ -49,6 +49,7 @@ args+=("-n" "$CONJUR_NAMESPACE" \
 if [[ "$PLATFORM" == "openshift" ]]; then
   args+=("--set" "image.repository=$IMAGE_REPOSITORY" \
          "--set" "image.tag=$IMAGE_TAG" \
+         "--set" "fullnameOverride=conjur-oss" \
          "--set" "nginx.image.repository=$NGINX_REPOSITORY" \
          "--set" "nginx.image.tag=$NGINX_TAG" \
          "--set" "postgres.image.repository=$POSTGRES_REPOSITORY" \


### PR DESCRIPTION
In conjur-oss-helm-chart the release name defaults to conjur-oss and with that is the service name. Now in conjur-authn-k8s-client the release name has a unique id that is passed into conjur-oss-helm-chart. This change will keep the service name to conjur-oss regardless of the release name, which is how conjur-oss-helm-chart was running previously as
it does not use the unique id.

### Desired Outcome

oc get service
NAME                             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)         AGE
conjur-oss                       NodePort    172.30.161.87   <none>        443:32333/TCP   43h

### Implemented Changes

The service name will default to the fullnameOverride

### Connected Issue/Story

Works towards [App deployment on Openshift](https://github.com/cyberark/conjur-authn-k8s-client/issues/346)



### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
