### PR TITLE
Bump conjur oss version

### DIFF
--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -68,7 +68,7 @@ image:
   # repository: registry.connect.redhat.com/cyberark/conjur
   # tag: latest
   repository: cyberark/conjur  # https://hub.docker.com/r/cyberark/conjur/
-  tag: '1.11.5'
+  tag: 'latest'
   pullPolicy: Always
 
 nginx:


### PR DESCRIPTION
Always use latest released conjur oss. This bump is done for conjur authn k8s client test be able to work with JWT authenticator