### PR TITLE
Fix broken builds on conjur-authn-k8s-client repo

### DIFF
--- a/ci/jenkins_build.sh
+++ b/ci/jenkins_build.sh
@@ -24,7 +24,8 @@ source ../utils.sh
 #                         This is useful for local testing whereby you've
 #                         already authenticated with GCP and/or have 'kubectl'
 #                         access to a cluster. Defaults to 'false'.
-#   AUTHN_STRATEGY:       Strategy of authentication. Can be authn-jwt or authn-k8s, defaults to authn-k8s
+#   AUTHN_STRATEGY:       Strategy of authentication. Can be authn-jwt or
+#                         authn-k8s, defaults to authn-k8s
 
 test_id="$(random_string)"
 
@@ -35,7 +36,7 @@ export HELM_VERSION="${HELM_VERSION:-3.1.3}"
 export KUBECTL_VERSION="${KUBECTL_VERSION:-1.16.9}"
 export RELEASE_NAME="$CONJUR_NAMESPACE"
 export SKIP_GCLOUD_LOGIN="${SKIP_GCLOUD_LOGIN:-false}"
-export AUTHN_STRATEGY="authn-k8s"
+export AUTHN_STRATEGY="${AUTHN_STRATEGY:-authn-k8s}"
 
 announce "Building gcloud/kubectl/helm client image..."
 # Build the gcloud/kubectl/helm client container image

--- a/examples/common/customize.env
+++ b/examples/common/customize.env
@@ -42,9 +42,7 @@
 #export TEST_APP_DATABASE="<postgres-or-mysql-defaults-to-postgres>"
 #export TEST_APP_NAMESPACE_NAME="<test-app-namespace-name-defaults-to-app-test>"
 
-# Configuration for Conjur authn-k8s
+# Configuration for Conjur authentication
 #export ANNOTATION_BASED_AUTHN="<true-or-false-defaults-to-true>"
+#export AUTHN_STRATEGY="<authn-jwt-or-authn-k8s-defaults-to-authn-k8s>"
 #export AUTHENTICATOR_ID="<authenticator-id-string-defaults-to-my-authenticator-id>"
-
-# Strategy of authentication. Can be authn-jwt or authn-k8s, defaults to authn-k8s
-#export AUTNH_STRATEGY="authn-k8s"

--- a/examples/kubernetes-in-docker/0_export_env_vars.sh
+++ b/examples/kubernetes-in-docker/0_export_env_vars.sh
@@ -16,8 +16,9 @@ export CONJUR_LOG_LEVEL="${CONJUR_LOG_LEVEL:-info}"
 export TEST_APP_DATABASE="${TEST_APP_DATABASE:-postgres}"
 export TEST_APP_NAMESPACE_NAME="${TEST_APP_NAMESPACE_NAME:-app-test}"
 
-# Configuration for Conjur authn-k8s
+# Configuration for Conjur authentication
 export ANNOTATION_BASED_AUTHN="${ANNOTATION_BASED_AUTHN:-true}"
+export AUTHN_STRATEGY="${AUTHN_STATEGY:-authn-k8s}"
 export AUTHENTICATOR_ID="${AUTHENTICATOR_ID:-my-authenticator-id}"
 
 # Conjur OSS Helm chart specific setting for demo scripts
@@ -44,5 +45,3 @@ if [[ "USE_DOCKER_LOCAL_REGISTRY" == "false" ]]; then
   check_env_var "DOCKER_PASSWORD"
   check_env_var "DOCKER_EMAIL"
 fi
-
-export AUTNH_STRATEGY="authn-k8s"

--- a/examples/openshift/0_export_env_vars.sh
+++ b/examples/openshift/0_export_env_vars.sh
@@ -16,8 +16,9 @@ export CONJUR_LOG_LEVEL="${CONJUR_LOG_LEVEL:-info}"
 export TEST_APP_DATABASE="${TEST_APP_DATABASE:-postgres}"
 export TEST_APP_NAMESPACE_NAME="${TEST_APP_NAMESPACE_NAME:-app-test}"
 
-# Configuration for Conjur authn-k8s
+# Configuration for Conjur authentication
 export ANNOTATION_BASED_AUTHN="${ANNOTATION_BASED_AUTHN:-true}"
+export AUTHN_STRATEGY="${AUTHN_STATEGY:-authn-k8s}"
 export AUTHENTICATOR_ID="${AUTHENTICATOR_ID:-my-authenticator-id}"
 
 # Conjur OSS Helm chart specific setting for demo scripts
@@ -56,5 +57,3 @@ if [[ "USE_DOCKER_LOCAL_REGISTRY" == "false" ]]; then
   check_env_var "DOCKER_PASSWORD"
   check_env_var "DOCKER_EMAIL"
 fi
-
-export AUTNH_STRATEGY="authn-k8s"


### PR DESCRIPTION


### Desired Outcome

Automated tests should not fail on the `conjur-authn-k8s-client` repo.

Jenkins tests and Github Actions tests on the conjur-authn-k8s-client repo are currently failing. Root cause appears to be that the example scripts in conjur-oss-helm-chart aren't setting a default value for the `AUTHN_STRATEGY` environment variable.

### Implemented Changes

- Added default value for AUTHN_STRATEGY environment variables for example scripts.
- Fixed some typos.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done

- [ ] Automated tests run for this repo.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
