### PR TITLE
Add unique keys for template dependency checksum annotations

### DIFF
--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
       labels: *AppConjurLabels
       annotations:
         # Automatically roll deployment if dependent secrets have been changed
-        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/ssl-cert.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/ssl-cert: {{ include (print $.Template.BasePath "/ssl-cert.yaml") . | sha256sum }}
+        checksum/nginx-configmap: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "conjur-oss.service-account" . }}
       volumes:

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -42,7 +42,7 @@ spec:
     metadata:
       labels: *AppPostgresLabels
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       securityContext:
         fsGroup: 999


### PR DESCRIPTION
### Desired Outcome

The Conjur deployment is configured by injecting Secrets and ConfigMaps into its containers, defined in the following templates:
- `secrets.yaml`
- `ssl-cert.yaml`
- `nginx-configmap.yaml`

If these files are changed, they need to trigger a restart of the Conjur deployment. This is done by assigning each file's checksum to a Pod annotation - however, all three of the files were given the same annotation key, `checksum.config`. This meant that each checksum would overwrite the checksum prior, so changes to these files would not trigger a Deployment roll.

This behavior manifested as a bug when trying to update an existing Conjur deployment with `helm upgrade`.
If trying to update the authenticators allowlist with the following:
```
helm upgrade <helm-release> cyberark/conjur-oss \
  --reuse-values \
  --set authenticators="authn\,authn-k8s/service-id" \
```
The K8s Secret representing the allowlist would be updated, but its updated checksum would be overridden by a static checksum for `nginx-configmap.yaml`, so they changes would not cause a Deployment roll.

### Implemented Changes

This PR gives each template file's checksum a unique annotation key, in `deployment.yaml` and `postgres.yaml`:
- `checksum/secrets`
- `checksum/ssl-cert`
- `checksum/nginx-configmap`

There is only one checksum in `postgres.yaml`, so it was not affected by this bug, but it was updated for consistent style.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
