### PR TITLE
Use Conjur CLI v8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,21 +36,19 @@ jobs:
     strategy:
       matrix:
         kube-tag:
+          - v1.26.0
           - v1.21.2
-          - v1.18.2
-          - v1.16.9
-          - v1.14.10
     steps:
       - name: Check out code
         uses: actions/checkout@v2
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.2.1
 
       - name: Create k8s KinD Cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.4.0
         with:
           node_image: "kindest/node:${{ matrix.kube-tag }}"
           cluster_name: kube-${{ matrix.kube-tag }}
@@ -59,7 +57,7 @@ jobs:
         run: ./test-minimal.sh
 
   install-test-helm-v2:
-    name: Install/test Conjur with Helm V2 on KinD Cluster (v1.18.2)
+    name: Install/test Conjur with Helm V2 on KinD Cluster (v1.21.2)
     needs:
       - linter
       - install-test-helm-v3
@@ -74,12 +72,12 @@ jobs:
           version: v2.17.0
 
       - name: Create k8s KinD Cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.4.0
         with:
-          node_image: "kindest/node:v1.18.2"
-          cluster_name: kube-v1.18.2-helm2
+          node_image: "kindest/node:v1.21.2"
+          cluster_name: kube-v1.21.2-helm2
 
-      - name: Initialise Helm
+      - name: Initialize Helm
         run: |
           # Service account with cluster-admin role for Helm
           echo "
@@ -103,7 +101,7 @@ jobs:
               namespace: kube-system
           " | kubectl create -f -
 
-          # Initialise
+          # Initialize
           helm init --stable-repo-url https://charts.helm.sh/stable --service-account tiller --wait
 
       - name: Run integration tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [2.0.6] - 2023-03-08
+
+### Changed
+- Updated notices to use Conjur CLI v8.0.
+  [cyberark/conjur-oss-helm-chart#179](https://github.com/cyberark/conjur-oss-helm-chart/pull/179)
+
 ## [2.0.5] - 2022-08-17
 
 ### Added
@@ -159,7 +165,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - First version of chart available.
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.5...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.6...HEAD
+[2.0.6]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.5...v2.0.6
 [2.0.5]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v2.0.2...v2.0.3

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -1,7 +1,7 @@
-GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
-GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
-GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
-GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
+GCLOUD_CLUSTER_NAME: !var ci/gke/rapid/cluster-name
+GCLOUD_PROJECT_NAME: !var ci/gke/project-name
+GCLOUD_SERVICE_KEY: !var:file ci/gke/service-key
+GCLOUD_ZONE: !var ci/gke/zone
 
 DOCKER_REGISTRY_URL: us.gcr.io
-DOCKER_REGISTRY_PATH: us.gcr.io/conjur-gke-dev
+DOCKER_REGISTRY_PATH: us.gcr.io/refreshing-mark-284016

--- a/conjur-oss/templates/NOTES.txt
+++ b/conjur-oss/templates/NOTES.txt
@@ -75,22 +75,22 @@
 
   Start a container with Conjur CLI and authenticate with the new user:
 
-      docker run --rm -it --entrypoint bash cyberark/conjur-cli:5
+      docker run --rm -it --entrypoint bash cyberark/conjur-cli:8
       # Or if using MiniKube, use the following command from the host:
-      # docker run --rm -it --network host --entrypoint bash cyberark/conjur-cli:5
+      # docker run --rm -it --network host --entrypoint bash cyberark/conjur-cli:8
 
       # Here ENDPOINT is the DNS name https endpoint for your Conjur service.
       # NOTE: Ensure that the target endpoint matches at least one of the expected server
       #       SSL certificate names otherwise SSL verification will fail and you will not
       #       be able to log in.
       # NOTE: Also ensure that the URL does not contain a slash (`/`) at the end of the URL
-      conjur init -u <ENDPOINT> -a {{ .Values.account.name | quote }}
+      conjur init -u <ENDPOINT> -a {{ .Values.account.name | quote }} --self-signed
 
       # API key here is the key that creation of the account provided you in step #2
-      conjur authn login -u admin -p <API_KEY>
+      conjur login -i admin -p <API_KEY>
 
       # Check that you are identified as the admin user
-      conjur authn whoami
+      conjur whoami
 
 4. Next Steps
   - Go through the Conjur Tutorials: https://www.conjur.org/tutorials/

--- a/examples/common/README.md
+++ b/examples/common/README.md
@@ -469,9 +469,9 @@ export CLI_POD="$(kubectl get pods -n conjur-oss -l app=conjur-cli \
         -o jsonpath='{.items[0].metadata.name}')"
 CONJUR_URL="https://conjur-oss.conjur-oss.svc.cluster.local"
 kubectl exec -n conjur-oss $CLI_POD \
-        -- bash -c "yes yes | conjur init -a $CONJUR_ACCOUNT -u $CONJUR_URL"
-kubectl exec -n conjur-oss $CLI_POD -- conjur authn login \
-        -u admin -p $ADMIN_PASSWORD
+        -- bash -c "yes yes | conjur init -a $CONJUR_ACCOUNT -u $CONJUR_URL --self-signed"
+kubectl exec -n conjur-oss $CLI_POD -- conjur login \
+        -i admin -p $ADMIN_PASSWORD
 ```
 
 And then create a `conjur` alias if your shell supports aliases:
@@ -493,7 +493,7 @@ After that initial setup, Conjur commands can be executed using the `conjur`
 command alias, if you've created one:
 
 ```sh-session
-    $ conjur list variables | grep alice
+    $ conjur list -k variable | grep alice
       "myConjurAccount:user:alice",
     $
 ```
@@ -501,7 +501,7 @@ command alias, if you've created one:
 Or by using the `CONJUR_CMD` environment variable:
 
 ```sh-session
-    $ $CONJUR_CMD list variables | grep alice
+    $ $CONJUR_CMD list -k variable | grep alice
       "myConjurAccount:user:alice",
     $
 ```


### PR DESCRIPTION
### Desired Outcome

Update helm chart notices to use CLI v8.0.

### Implemented Changes

Updated README.md and conjur-oss/templates/NOTES.txt to refer to the v8 Conjur CLI tag and use the updated command syntax.
Updated CHANGELOG.md in preparation for new release of the helm chart, v2.0.6.

### Connected Issue/Story

Resolves #178

CyberArk internal issue ID: ONYX-33379

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
