### PR TITLE
Add option from datakey to be provided from existing secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [2.1.0] - 2023-07-11
+
+### Added
+- Support for using existing secrets for data key
+
 ## [2.0.6] - 2023-03-09
 
 ### Changed

--- a/conjur-oss/Chart.yaml
+++ b/conjur-oss/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: conjur-oss
 home: https://www.conjur.org
-version: 2.0.6
+version: 2.1.0
 description: A Helm chart for CyberArk Conjur
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
 keywords:

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -81,7 +81,7 @@ $  helm install \
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v$VERSION/conjur-oss-$VERSION.tgz
 ```
 
-_Note: You can import conjur data key as a secret existing on your kubernetes cluster using `--set dataKeySecretRef=YOUR_SECRET_NAME` where the secret is contained within the key `key`. Note that it will overwrite usage of dataKey._
+_Note: You can import conjur data key as a secret existing on your kubernetes cluster using `--set dataKeySecretRef=YOUR_SECRET_NAME` where the secret is contained within the key `key`. Note that you can't have dataKey and dataKeySecretRef together._
 
 _Note: The configured data key will be used to encrypt sensitive information
 in Conjur's database. This must be archived in a safe place._

--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -81,6 +81,8 @@ $  helm install \
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v$VERSION/conjur-oss-$VERSION.tgz
 ```
 
+_Note: You can import conjur data key as a secret existing on your kubernetes cluster using `--set dataKeySecretRef=YOUR_SECRET_NAME` where the secret is contained within the key `key`. Note that it will overwrite usage of dataKey._
+
 _Note: The configured data key will be used to encrypt sensitive information
 in Conjur's database. This must be archived in a safe place._
 

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -149,7 +149,7 @@ spec:
         - name: CONJUR_DATA_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-conjur-data-key
+              name: {{ .Values.dataKeySecretRef | default (printf "%s-conjur-data-key" .Release.Name)  }}
               key: key
         - name: DATABASE_URL
           valueFrom:

--- a/conjur-oss/templates/secrets.yaml
+++ b/conjur-oss/templates/secrets.yaml
@@ -17,6 +17,7 @@ type: Opaque
 data:
   key: "{{ .Values.authenticators | b64enc }}"
 ---
+{{- if not .Values.dataKeySecretRef }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -37,6 +38,7 @@ metadata:
 type: Opaque
 data:
   key: {{ .Values.dataKey | b64enc }}
+{{- end }}
 ---
 {{- include "conjur-oss.database-password" . }}
 apiVersion: v1

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -1,5 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
+  "oneOf": [
+    {
+      "required": ["dataKey"]
+    },
+    {
+      "required": ["dataKeySecretRef"]
+    }
+  ],
   "properties": {
     "account": {
       "type": "object",
@@ -30,9 +38,7 @@
         "ssl": {
           "dependencies": {
             "cert": {
-              "required": [
-                "key"
-              ]
+              "required": ["key"]
             }
           },
           "properties": {
@@ -56,10 +62,12 @@
       }
     },
     "dataKeySecretRef": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "dataKey": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "deployment": {
       "properties": {
@@ -91,8 +99,8 @@
             "tag": {
               "type": "string"
             },
-              "pullPolicy": {
-                "type": "string"
+            "pullPolicy": {
+              "type": "string"
             }
           }
         }
@@ -191,11 +199,7 @@
     "ssl": {
       "dependencies": {
         "cert": {
-          "required": [
-            "key",
-            "caCert",
-            "caKey"
-          ]
+          "required": ["key", "caCert", "caKey"]
         }
       },
       "properties": {

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -1,8 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "required": [
-    "dataKey"
-  ],
   "properties": {
     "account": {
       "type": "object",
@@ -58,9 +55,11 @@
         }
       }
     },
+    "dataKeySecretRef": {
+      "type": "string"
+    },
     "dataKey": {
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     },
     "deployment": {
       "properties": {

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -7,7 +7,9 @@
 # rather than setting these in a custom values YAML file. This avoids the
 # risk of leaving around residual values files containing this sensitive
 # information.
-dataKeySecretRef: "conjur-data-key"
+
+# Alternatively use `dataKeySecretRef` to specify the name of the secret
+# dataKeySecretRef: "conjur-data-key"
 
 account:
   # Name of Conjur account to be created. Maps to CONJUR_ACCOUNT env variable

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -7,7 +7,8 @@
 # rather than setting these in a custom values YAML file. This avoids the
 # risk of leaving around residual values files containing this sensitive
 # information.
-dataKeySecretRef: 
+dataKeySecretRef: "conjur-data-key"
+
 account:
   # Name of Conjur account to be created. Maps to CONJUR_ACCOUNT env variable
   # for the Conjur container.

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -7,7 +7,7 @@
 # rather than setting these in a custom values YAML file. This avoids the
 # risk of leaving around residual values files containing this sensitive
 # information.
-
+dataKeySecretRef: 
 account:
   # Name of Conjur account to be created. Maps to CONJUR_ACCOUNT env variable
   # for the Conjur container.


### PR DESCRIPTION
### Desired Outcome

The secret doesn't show in the helm values

### Implemented Changes

Allow to use existing secrets in the cluster

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
