### PR TITLE
Add resource values for nginx and postgres

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -377,6 +377,7 @@ The following table lists the configurable parameters of the Conjur Open Source 
 |`nginx.image.repository`|NGINX Docker image repository|`"nginx"`|
 |`nginx.image.tag`|NGINX Docker image tag|`"1.15"`|
 |`nginx.image.pullPolicy`|Pull policy for NGINX Docker image|`"IfNotPresent"`|
+|`nginx.resources`|Resource requests and limits for nginx pod|`{}`|
 |`openshift.enabled`|Indicates that Conjur is to be installed on an OpenShift platform|`false`|
 |`postgres.image.pullPolicy`|Pull policy for postgres Docker image|`"IfNotPresent"`|
 |`postgres.image.repository`|postgres Docker image repository|`"postgres"`|
@@ -384,8 +385,10 @@ The following table lists the configurable parameters of the Conjur Open Source 
 |`postgres.persistentVolume.create`|Create a peristent volume to back the PostgreSQL data|`true`|
 |`postgres.persistentVolume.size`|Size of persistent volume to be created for PostgreSQL|`"8Gi"`|
 |`postgres.persistentVolume.storageClass`|Storage class to be used for PostgreSQL persistent volume claim|`nil`|
+|`postgres.resources`|Resource requests and limits for postgres pod|`{}`|
 |`rbac.create`|Controls whether or not RBAC resources are created. This setting is deprecated and will be replaced in the next major release with two separate settings: `rbac.createClusterRole` (defaulting to true) and `rbac.createClusterRoleBinding` (defaulting to false), and the creation of RoleBindings will be recommended over relying on this ClusterRoleBinding.|`true`|
 |`replicaCount`|Number of desired Conjur pods|`1`|
+|`resources`|Resource requests and limits for conjur pod|`{}`|
 |`service.external.annotations`|Annotations for the external LoadBalancer|`[service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp]`|
 |`service.external.enabled`|Expose service to the Internet|`true`|
 |`service.external.port`|Conjur external service port|`443`|

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -96,7 +96,8 @@ spec:
           mountPath: /etc/nginx
           readOnly: true
         {{- end }}
-
+        resources:
+{{ toYaml .Values.nginx.resources | indent 12 }}
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -69,6 +69,8 @@ spec:
         - name: ssl-certs
           mountPath: "/etc/certs"
           readOnly: true
+        resources:
+{{ toYaml .Values.postgres.resources | indent 10 }}
       volumes:
 {{ if .Values.postgres.persistentVolume.create }}
       - name: postgres-data

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -96,6 +96,9 @@
                 "type": "string"
             }
           }
+        },
+        "resources": {
+          "type": "object"
         }
       }
     },
@@ -129,6 +132,9 @@
               "type": "string"
             }
           }
+        },
+        "resources": {
+          "type": "object"
         }
       }
     },

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -81,6 +81,16 @@ nginx:
     repository: nginx          # https://hub.docker.com/_/nginx/
     tag: '1.15'
     pullPolicy: Always
+
+  # If you do want to specify resources, uncomment the following lines, adjust
+  # them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+  resources: {}
       
 # nodeSelector (node selection constraints) to apply to the Conjur pod. Refer to:
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
@@ -102,6 +112,16 @@ postgres:
     size: 8Gi
     # Set storageClass to use a non-default storage class for your platform
     # storageClass:
+
+  # If you do want to specify resources, uncomment the following lines, adjust
+  # them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+  resources: {}
 
 # Additional labels to apply to all postgres-related resources
 postgresLabels: {}


### PR DESCRIPTION
### Desired Outcome

Expose chart values to set resource requests and limits on nginx + postgres pods.

### Implemented Changes

Resource value configuration has been exposed allowing users to customise requests + limits for nginx + postgres pods. This was a requirement for our cluster as we have strict policies in place that require all pods to have resources defined.

### Connected Issue/Story

n/a

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
