### PR TITLE
docs: fix Postgresql image version in OCP example

### DIFF
--- a/conjur-oss/README.md
+++ b/conjur-oss/README.md
@@ -127,7 +127,7 @@ $  helm install \
    --set image.tag=latest \
    --set nginx.image.repository=registry.connect.redhat.com/cyberark/conjur-nginx \
    --set nginx.image.tag=latest \
-   --set postgres.image.repository=registry.redhat.io/rhscl/postgresql-10-rhel7 \
+   --set postgres.image.repository=registry.redhat.io/rhel8/postgresql-15 \
    --set postgres.image.tag=latest \
    --set openshift.enabled=true \
    --set dataKey="$DATA_KEY" \


### PR DESCRIPTION
The minimum compatible version for PostgreSQL is 14 with the "CREATE OR REPLACE TRIGGER" command.

https://www.postgresql.org/docs/14/sql-createtrigger.html

### Desired Outcome

The Helm Chart deployment example in OCP generates an error in the conjur-oss container due to instructions that are not compatible with PostgreSQL versions lower than 14:

Caused by:
PG::SyntaxError: ERROR: syntax error at or near "TRIGGER" (PG::SyntaxError)
LINE 84: CREATE OR REPLACE TRIGGER grant_role_membership_to_own...

### Implemented Changes

The OCP example is updated with the default version of the example that appears in the README.md file of the Helm Chart TGZ itself.
