### PR TITLE
feat(conjur-oss): Add support for external secrets in GitOps deployments

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,33 @@
+name: Unit Tests
+
+on:
+  # Run this on pushes to main
+  push:
+    branches:
+    - main
+
+  # Or when PR operations are done
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+
+jobs:
+  unittest:
+    name: Run Helm Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.0
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 0.3.6
+
+      - name: Run unit tests
+        run: helm unittest ./conjur-oss

--- a/conjur-oss/templates/_helpers.tpl
+++ b/conjur-oss/templates/_helpers.tpl
@@ -55,8 +55,8 @@ Use the database password chart value if provided, or generate a
 64-character, random, alphanumeric password for the backend database
 */}}
 {{- define "conjur-oss.database-password" -}}
-{{- if .Values.database.password }}
-{{- $_ := set . "dbPassword" (.Values.database.password | trunc 64) }}
+{{- if .Values.database.secrets.password }}
+{{- $_ := set . "dbPassword" (.Values.database.secrets.password | trunc 64) }}
 {{- else }}
 {{- $_ := set . "dbPassword" (randAlphaNum 64) }}
 {{- end }}

--- a/conjur-oss/templates/deployment.yaml
+++ b/conjur-oss/templates/deployment.yaml
@@ -159,12 +159,20 @@ spec:
         - name: CONJUR_DATA_KEY
           valueFrom:
             secretKeyRef:
+{{- if .Values.createDataKeySecret }}
               name: {{ .Release.Name }}-conjur-data-key
+{{- else }}
+              name: {{ .Values.dataKeySecretName }}
+{{- end }}
               key: key
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
+{{- if .Values.database.secrets.createDatabasePasswordSecrets }}
               name: {{ .Release.Name }}-conjur-database-url
+{{- else }}
+              name: {{ .Values.database.secrets.databaseUrlSecret }}
+{{- end }}
               key: key
         - name: CONJUR_ACCOUNT
           value: {{ .Values.account.name }}

--- a/conjur-oss/templates/postgres.yaml
+++ b/conjur-oss/templates/postgres.yaml
@@ -57,7 +57,11 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
+{{- if .Values.database.secrets.createDatabasePasswordSecrets }}
               name: {{ .Release.Name }}-conjur-database-password
+{{- else }}
+              name: {{ .Values.database.secrets.databasePasswordSecret }}
+{{- end }}
               key: key
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata

--- a/conjur-oss/templates/secrets.yaml
+++ b/conjur-oss/templates/secrets.yaml
@@ -16,6 +16,7 @@ metadata:
 type: Opaque
 data:
   key: "{{ .Values.authenticators | b64enc }}"
+{{- if .Values.createDataKeySecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -37,6 +38,8 @@ metadata:
 type: Opaque
 data:
   key: {{ .Values.dataKey | b64enc }}
+{{- end }}
+{{- if .Values.database.secrets.createDatabasePasswordSecrets }}
 ---
 {{- include "conjur-oss.database-password" . }}
 apiVersion: v1
@@ -65,8 +68,9 @@ data:
   {{ else }}
   key: {{ printf "postgres://postgres:%s@%v-postgres/postgres?sslmode=require" .dbPassword .Release.Name | b64enc }}
   {{ end }}
+{{- end }}
 
-{{ if eq .Values.database.url "" }}
+{{ if and (eq .Values.database.url "") .Values.database.secrets.createDatabasePasswordSecrets }}
 ---
 apiVersion: v1
 kind: Secret

--- a/conjur-oss/tests/common-metadata_test.yaml
+++ b/conjur-oss/tests/common-metadata_test.yaml
@@ -7,6 +7,10 @@ tests:
   - it: "should contain labels metadata in each default template"
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       exportAPIkey:
         enabled: true
     templates:
@@ -31,9 +35,14 @@ tests:
             app.kubernetes.io/name: conjur-oss
             heritage: Helm
             release: conjur-oss
+
   - it: "should contain labels metadata in postgres template"
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       postgres:
         persistentVolume:
           create: true
@@ -54,9 +63,14 @@ tests:
             app.kubernetes.io/component: postgres
             heritage: Helm
             release: conjur-oss
+
   - it: "should contain labels metadata in postgres-ocp templates"
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       openshift:
         enabled: true
     templates:
@@ -75,4 +89,4 @@ tests:
             app.kubernetes.io/name: conjur-oss
             app.kubernetes.io/component: postgres
             heritage: Helm
-            release: conjur-oss            
+            release: conjur-oss

--- a/conjur-oss/tests/deployment_test.yaml
+++ b/conjur-oss/tests/deployment_test.yaml
@@ -8,8 +8,11 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
       database:
-        password: "password"
+        secrets:
+          createDatabasePasswordSecrets: true
+          password: "password"
         ssl:
           # Dummy base64-encoded cert and key values
           cert: ZHVtbXlfY2VydAo=
@@ -22,11 +25,15 @@ tests:
         key: ZHVtbXlfa2V5Cg== #gitleaks:allow
     asserts:
       - matchSnapshot: {}
+
   - it: should have additional volumes if exportAPIkey is enabled
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
       database:
-        password: "password"
+        secrets:
+          createDatabasePasswordSecrets: true
+          password: "password"
       exportAPIkey:
         enabled: true
     template: deployment.yaml
@@ -36,16 +43,21 @@ tests:
           content:
             name: RELEASE-NAME-authn-local-socket-volume
           any: true
+
   - it: should include resources if specified
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       nginx:
         resources:
           requests:
             cpu: "100m"
       resources:
         requests:
-          cpu: "200m"            
+          cpu: "200m"
     template: "deployment.yaml"
     asserts:
       - equal:
@@ -54,3 +66,32 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: "200m"
+
+  - it: should reference external data key secret when createDataKeySecret is false
+    set:
+      createDataKeySecret: false
+      dataKeySecretName: "my-external-data-key"
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
+          password: "password"
+    template: "deployment.yaml"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].env[?(@.name=="CONJUR_DATA_KEY")].valueFrom.secretKeyRef.name
+          value: "my-external-data-key"
+
+  - it: should reference external database URL secret when createDatabasePasswordSecrets is false
+    set:
+      dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: false
+          databaseUrlSecret: "my-external-db-url"
+          databasePasswordSecret: "my-external-db-password"
+    template: "deployment.yaml"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].env[?(@.name=="DATABASE_URL")].valueFrom.secretKeyRef.name
+          value: "my-external-db-url"

--- a/conjur-oss/tests/exportapikey-configmap_test.yaml
+++ b/conjur-oss/tests/exportapikey-configmap_test.yaml
@@ -5,6 +5,10 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       exportAPIkey:
         enabled: true
     asserts:
@@ -12,8 +16,12 @@ tests:
   - it: should not create the ExportAPIKey ConfigMap if exportAPIkey isn't enabled
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       exportAPIkey:
         enabled: false
     asserts:
-      - notExists:
-          path: metadata.name        
+      - hasDocuments:
+          count: 0        

--- a/conjur-oss/tests/load-balancer_test.yaml
+++ b/conjur-oss/tests/load-balancer_test.yaml
@@ -5,14 +5,23 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
     asserts:
       - matchSnapshot: {}
+
   - it: should not create any service if 'service.external.enabled' is false
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       service:
         external:
-          enabled: false      
+          enabled: false
     asserts:
-      - notExists:
-          path: metadata.name
+      - hasDocuments:
+          count: 0

--- a/conjur-oss/tests/nginx-configmap_test.yaml
+++ b/conjur-oss/tests/nginx-configmap_test.yaml
@@ -5,8 +5,12 @@ tests:
   - it: should not create any ConfigMap if 'openshift.enabled' is true
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       openshift:
         enabled: true
     asserts:
-      - notExists:
-          path: metadata.name
+      - hasDocuments:
+          count: 0

--- a/conjur-oss/tests/persistent-volume-claim_test.yaml
+++ b/conjur-oss/tests/persistent-volume-claim_test.yaml
@@ -5,20 +5,34 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
     asserts:
       - matchSnapshot: {}
+
   - it: should not create any PVC if 'postgres.persistentVolume.create' is false
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       postgres:
         persistentVolume:
-          create: false    
+          create: false
     asserts:
-      - notExists:
-          path: metadata.name
+      - hasDocuments:
+          count: 0
+
   - it: should create a PVC with the specified storage class if 'postgres.persistentVolume.storageClass' is set
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       postgres:
         persistentVolume:
           storageClass: "custom-storage-class"

--- a/conjur-oss/tests/postgres-ocp-ssl-configmap_test.yaml
+++ b/conjur-oss/tests/postgres-ocp-ssl-configmap_test.yaml
@@ -5,15 +5,24 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       openshift:
         enabled: true
     asserts:
       - matchSnapshot: {}
+
   - it: should not create the ConfigMap if 'openshift.enabled' is false
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       openshift:
         enabled: false
     asserts:
-      - notExists:
-          path: metadata.name      
+      - hasDocuments:
+          count: 0

--- a/conjur-oss/tests/postgres-ocp_test.yaml
+++ b/conjur-oss/tests/postgres-ocp_test.yaml
@@ -5,50 +5,64 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       openshift:
         enabled: true
     asserts:
       - matchSnapshot: {}
+
   - it: should not create the Postgres Openshift enabled manifests if 'openshift.enabled' is false
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       openshift:
         enabled: false
     asserts:
-      - notExists:
-          path: metadata.name      
+      - hasDocuments:
+          count: 0
+
   - it: should not mount a PVC if 'postgres.persistentVolume.create' is false
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       postgres:
         persistentVolume:
           create: false
       openshift:
-        enabled: true          
+        enabled: true
+    documentIndex: 1
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
-          content: 
-            name: postgres-data
-          any: true
-      - notContains:
-          path: spec.template.spec.volumes
           content:
             name: postgres-data
+          any: true
+
   - it: should include resources if specified
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       postgres:
         resources:
           requests:
             cpu: "100m"
       openshift:
-        enabled: true            
+        enabled: true
     template: "postgres-ocp.yaml"
-    documentSelector:
-      path: kind
-      value: StatefulSet
+    documentIndex: 1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: "100m"          
+          value: "100m"

--- a/conjur-oss/tests/postgres_test.yaml
+++ b/conjur-oss/tests/postgres_test.yaml
@@ -6,52 +6,82 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
       openshift:
         enabled: false
       database:
-        password: "password"
+        secrets:
+          createDatabasePasswordSecrets: true
+          password: "password"
         ssl:
           # Dummy base64-encoded cert and key values
           cert: ZHVtbXlfY2VydAo=
           key: ZHVtbXlfa2V5Cg== #gitleaks:allow
     asserts:
       - matchSnapshot: {}
+
   - it: should not create the non Openshift enabled Postgres manifests if 'openshift.enabled' is true
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       openshift:
         enabled: true
+    template: "postgres.yaml"
     asserts:
-      - notExists:
-          path: spec.template.spec.containers
+      - hasDocuments:
+          count: 0
+
   - it: should not mount a PVC if 'postgres.persistentVolume.create' is false
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       postgres:
         persistentVolume:
           create: false
+    template: "postgres.yaml"
+    documentIndex: 1
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
-          content: 
-            name: postgres-data
-          any: true
-      - notContains:
-          path: spec.template.spec.volumes
           content:
             name: postgres-data
+          any: true
+
   - it: should include resources if specified
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       postgres:
         resources:
           requests:
             cpu: "100m"
     template: "postgres.yaml"
-    documentSelector:
-      path: kind
-      value: StatefulSet
+    documentIndex: 1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: "100m"
+
+  - it: should reference external database password secret when createDatabasePasswordSecrets is false
+    set:
+      dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: false
+          databasePasswordSecret: "my-external-db-password"
+    template: "postgres.yaml"
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: "my-external-db-password"

--- a/conjur-oss/tests/rbac_test.yaml
+++ b/conjur-oss/tests/rbac_test.yaml
@@ -5,20 +5,30 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
     templates:
       - auth-role.yaml
     asserts:
       - matchSnapshot: {}
+
   - it: should create an additional RBAC rule if exportAPIkey is enabled
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       exportAPIkey:
         enabled: true
     template: auth-role.yaml
-    documentSelector:
-      path: kind
-      value: ClusterRole
+    documentIndex: 1
     asserts:
+      - equal:
+          path: kind
+          value: ClusterRole
       - contains:
           path: rules
           content:

--- a/conjur-oss/tests/secrets_test.yaml
+++ b/conjur-oss/tests/secrets_test.yaml
@@ -5,34 +5,106 @@ tests:
   - it: should create an SSL cert for d/b access if no cert values provided
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
       database:
-        password: "password"
+        secrets:
+          createDatabasePasswordSecrets: true
+          password: "password"
     template: "secrets.yaml"
-    documentSelector:
-      path: metadata.name
-      value: RELEASE-NAME-conjur-database-ssl
+    documentIndex: 4
     asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-conjur-database-ssl
       - equal:
           path: metadata.annotations["helm.sh/hook"]
           value: pre-install
       - matchRegex:
           path: data["tls.crt"]
-          # Check that the first 500 chars are valid base64 (Go regex only supports upto 1000 chars BTW) and check that the last chars are 0, 1 or 2 '='
+          # Check that the first 500 chars are valid base64
           pattern: ^[A-Za-z0-9+/]{500,}={0,2}$
+
   - it: should use the 'database.url' if provided
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
       database:
-        password: "password"
+        secrets:
+          createDatabasePasswordSecrets: true
+          password: "password"
         url: "postgres://user:password@host:port/dbname"
     template: "secrets.yaml"
-    documentSelector:
-      path: metadata.name
-      value: RELEASE-NAME-conjur-database-url
+    documentIndex: 2
     asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-conjur-database-url
       - notExists:
           path: metadata.annotations["helm.sh/hook"]
       - equal:
           path: data["key"]
           value: "postgres://user:password@host:port/dbname"
           decodeBase64: true
+
+  - it: should create data-key secret when createDataKeySecret is true
+    set:
+      dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
+          password: "password"
+    template: "secrets.yaml"
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-conjur-data-key
+      - equal:
+          path: data["key"]
+          value: "1234567890"
+          decodeBase64: true
+
+  - it: should NOT create data-key secret when createDataKeySecret is false
+    set:
+      createDataKeySecret: false
+      dataKeySecretName: "external-data-key"
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
+          password: "password"
+    template: "secrets.yaml"
+    asserts:
+      - notMatchRegex:
+          path: metadata.name
+          pattern: ".*conjur-data-key$"
+
+  - it: should NOT create database-url secret when createDatabasePasswordSecrets is false
+    set:
+      dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: false
+          databaseUrlSecret: "external-db-url"
+          databasePasswordSecret: "external-db-password"
+    template: "secrets.yaml"
+    asserts:
+      - notMatchRegex:
+          path: metadata.name
+          pattern: ".*conjur-database-url$"
+
+  - it: should NOT create database-password secret when createDatabasePasswordSecrets is false
+    set:
+      dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: false
+          databaseUrlSecret: "external-db-url"
+          databasePasswordSecret: "external-db-password"
+    template: "secrets.yaml"
+    asserts:
+      - notMatchRegex:
+          path: metadata.name
+          pattern: ".*conjur-database-password$"

--- a/conjur-oss/tests/secrets_test.yaml
+++ b/conjur-oss/tests/secrets_test.yaml
@@ -21,7 +21,7 @@ tests:
           value: pre-install
       - matchRegex:
           path: data["tls.crt"]
-          # Check that the first 500 chars are valid base64
+          # Check that the first 500 chars are valid base64 (Go regex only supports upto 1000 chars BTW) and check that the last chars are 0, 1 or 2 '='
           pattern: ^[A-Za-z0-9+/]{500,}={0,2}$
 
   - it: should use the 'database.url' if provided

--- a/conjur-oss/tests/service_test.yaml
+++ b/conjur-oss/tests/service_test.yaml
@@ -5,11 +5,20 @@ tests:
   - it: should match snapshot of default values
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
     asserts:
       - matchSnapshot: {}
+
   - it: should include annotations if specified
     set:
       dataKey: "1234567890"
+      createDataKeySecret: true
+      database:
+        secrets:
+          createDatabasePasswordSecrets: true
       service:
         internal:
           annotations:

--- a/conjur-oss/values.schema.json
+++ b/conjur-oss/values.schema.json
@@ -1,9 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "required": [
-    "dataKey"
+    "createDataKeySecret"
   ],
   "properties": {
+    "createDataKeySecret": {
+      "type": "boolean"
+    },
+    "dataKeySecretName": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 63
+    },
     "account": {
       "type": "object",
       "properties": {
@@ -26,9 +34,27 @@
       "type": "object"
     },
     "database": {
+      "type": "object",
       "properties": {
-        "password": {
-          "type": "string"
+        "secrets": {
+          "type": "object",
+          "required": [
+            "createDatabasePasswordSecrets"
+          ],
+          "properties": {
+            "createDatabasePasswordSecrets": {
+              "type": "boolean"
+            },
+            "password": {
+              "type": "string"
+            },
+            "databaseUrlSecret": {
+              "type": "string"
+            },
+            "databasePasswordSecret": {
+              "type": "string"
+            }
+          }
         },
         "ssl": {
           "dependencies": {

--- a/conjur-oss/values.yaml
+++ b/conjur-oss/values.yaml
@@ -33,10 +33,43 @@ conjurLabels: {}
 logLevel: "info"
 
 database:
-  # PostgreSQL connection password. If left blank, a pseudo-random,
-  # 64-character alphanumeric password will be auto-generated.
-  # Note that this value will be ignored for Helm upgrade operations.
-  password: ""
+  secrets:
+    # Secrets can be generated automatically by Helm or they can be pre-existing secrets
+    # created outside Helm. Benefits to using pre-existing secrets include better support
+    # for ArgoCD or GitOps deployments where the deployer needs to control the secret
+    # lifecycle. Also avoids sync issues where conjur-oss and conjur-postgres can get
+    # out of sync with passwords when changes are made via GitOps.
+
+    # createDatabasePasswordSecrets: boolean
+    # true: create the secrets using either the value in "password" or generate one
+    # false: Use the fields 'databaseUrlSecret' and 'databasePasswordSecret' in the deployment
+    createDatabasePasswordSecrets: true
+
+    # PostgreSQL connection password. If left blank, a pseudo-random,
+    # 64-character alphanumeric password will be auto-generated.
+    # Note that this value will be ignored for Helm upgrade operations.
+    # Also Note: this value will be ignored when createDatabasePasswordSecrets is false
+    password: ""
+
+    # When createDatabasePasswordSecrets is set to false, the following values are used
+    # to reference existing secrets, preventing regeneration of credentials during GitOps.
+    # Also helps with secret rotation and management.
+    #
+    # database url secret should be a secret in the same namespace containing a base64
+    # encoded connection string:
+    # data:
+    #   key: <base64 encoded string>
+    # string format is:
+    #   postgres://postgres:%s@%v-postgres/postgres?sslmode=require
+    # where:
+    # %s = password (same value as `databasePasswordSecret`)
+    # %v = release name (usually <namespace>-<application-name> in GitOps deployments)
+    databaseUrlSecret: "conjur-database-url"
+
+    # Value within secret is a single base64 encoded string with the password.
+    # data:
+    #   key: <base64 encoded password>
+    databasePasswordSecret: "conjur-database-password"
 
   ssl:
     # Backend database SSL certificate and private key. These should be
@@ -54,8 +87,21 @@ database:
 
 # Conjur data key, 32 byte base-64 encoded string for data encryption.
 # Generate one with `docker run --rm cyberark/conjur data-key generate`.
-# This is a required setting.
+
+# Either provide dataKey directly or use dataKeySecretName to reference an existing secret.
+# createDataKeySecret: boolean
+# true: create the secret using the value in 'dataKey' (not recommended for git-committed values.yaml)
+# false: use an existing secret specified by 'dataKeySecretName'
+createDataKeySecret: true
+
+# If createDataKeySecret == true, provide the dataKey value here.
 # dataKey:
+
+# If createDataKeySecret == false, provide the name of an existing secret.
+# Secret must have the following structure:
+# data:
+#   key: <base64 encoded data-key>
+dataKeySecretName: "conjur-data-key"
 
 # Annotations to apply to the Conjur deployment.
 deployment:


### PR DESCRIPTION
# feat(conjur-oss): Add support for external secrets in GitOps deployments

## Related Issue

This PR extends the work started in #183 (Add Option from Datakey to be Provided from Existing Secret) by:
1. Completing the data key external secret feature with tests (addressing the blocker from #183)
2. Extending support to database secrets (URL and password)

## What does this PR do?

Adds the ability to reference pre-existing Kubernetes secrets instead of having Helm generate them. This is essential for GitOps workflows (ArgoCD, Flux) where:
- Secrets need to be managed externally (e.g., via Sealed Secrets, External Secrets Operator, Vault)
- Credential drift between Conjur and Postgres components must be prevented
- Secret lifecycle needs to be controlled independently of Helm releases

## Why is this change needed?

When deploying via GitOps tools, Helm-generated secrets cause issues:
- Secrets can be regenerate during GitOps workflows, causing credential mismatches
- No control over secret lifecycle (rotation, external management)
- Where external databases are managed outside of the chart on a HA cluster
- values.yaml cannot contain unencrypted secrets. (hash is not acceptable in a git workflow)

## New Configuration Options

### Data Key Secret

```yaml
# Option 1: Let Helm create the secret (default - backward compatible)
createDataKeySecret: true
dataKey: "<base64-encoded-32-byte-key>"

# Option 2: Use an existing secret
createDataKeySecret: false
dataKeySecretName: "my-existing-conjur-data-key"
```

### Database Secrets

```yaml
database:
  secrets:
    # Option 1: Let Helm create secrets (default - backward compatible)
    createDatabasePasswordSecrets: true
    password: ""  # Auto-generated if blank

    # Option 2: Use existing secrets
    createDatabasePasswordSecrets: false
    databaseUrlSecret: "my-existing-database-url"
    databasePasswordSecret: "my-existing-database-password"
```

## API Design Rationale

This PR uses explicit boolean flags (`createDataKeySecret`, `createDatabasePasswordSecrets`) following common Helm conventions:
- Matches patterns like `serviceAccount.create`, `rbac.create`, `persistence.enabled`
- Makes intent immediately clear in values.yaml
- Easier to template and understand
- Better for GitOps (explicit state, not inferred from presence)

This differs from PR #183's approach (`dataKeySecretRef` presence-based) but is more conventional and extends naturally to database secrets.

## Changes

### Templates Modified
- `templates/secrets.yaml` - Conditional creation of data-key and database secrets
- `templates/deployment.yaml` - Conditional secret name references for Conjur container
- `templates/postgres.yaml` - Conditional secret reference for Postgres container
- `templates/_helpers.tpl` - Updated password path to `database.secrets.password`

### Configuration Updated
- `values.yaml` - Added new configuration options with documentation
- `values.schema.json` - Added schema validation for new properties

### Tests Added/Updated
- Updated all existing tests to use new values structure
- Added new tests for external secrets functionality:
  - Verify secrets are NOT created when `create*` flags are false
  - Verify external secret names are correctly referenced in deployments
- Fixed pre-existing test bug: Changed `notExists` assertions to `hasDocuments: count: 0`
  for tests checking "template should render nothing" - the original `notExists` assertion
  fails when templates produce 0 documents

### CI Workflow Added
- `.github/workflows/unittest.yml` - Runs `helm unittest` on pull requests and pushes to main

## Backward Compatibility

- All new options default to `true`, preserving existing behavior
- No breaking changes for existing deployments
- Existing values.yaml files continue to work without modification

## How to Test

```bash
# Run unit tests
helm unittest ./conjur-oss

# Test with secrets creation (default)
helm template test ./conjur-oss \
  --set dataKey="test-key-12345678901234567890123456"

# Test with external secrets
helm template test ./conjur-oss \
  --set createDataKeySecret=false \
  --set dataKeySecretName="external-data-key" \
  --set database.secrets.createDatabasePasswordSecrets=false \
  --set database.secrets.databaseUrlSecret="external-db-url" \
  --set database.secrets.databasePasswordSecret="external-db-password"
```

## Integration Test Scope

This PR includes unit tests that verify templates render correctly for all external secrets scenarios. Integration tests for external database secrets are **out of scope** for this PR because:

- The existing integration tests deploy Postgres as part of the Helm chart
- Testing external database secrets would require deploying a separate external Postgres instance, creating secrets with its connection details, then verifying Conjur connects successfully
- This represents a significant expansion of the integration test infrastructure

The external secrets feature is primarily for GitOps users (ArgoCD, Flux) who manage secrets via External Secrets Operator, Sealed Secrets, or Vault. These users will validate the feature in their own environments as part of their deployment pipelines.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have updated the unit tests
- [x] All tests pass (`helm unittest ./conjur-oss`)
- [x] Changes are backward compatible
- [x] Documentation is included in values.yaml comments
- [x] Added CI workflow to run unit tests on PRs

## CHANGELOG Entry

```markdown
## [Unreleased]

### Added
- Support for referencing external secrets for data key and database credentials,
  enabling GitOps workflows where secrets are managed outside of Helm.
  [cyberark/conjur-oss-helm-chart#XXX](https://github.com/cyberark/conjur-oss-helm-chart/pull/XXX)
```

## Acknowledgments

This PR builds upon and completes the work started in #183 by @dan-transmit. The original PR introduced the concept of external data key secrets but was blocked on tests. This PR:
- Addresses the test requirement that blocked #183
- Extends the feature to include database secrets
- Uses a conventional boolean-flag API pattern
